### PR TITLE
Dftracer trace replay functionality with updated interfaces to the call-tree functionality

### DIFF
--- a/cmake/modules/Dependencies.cmake
+++ b/cmake/modules/Dependencies.cmake
@@ -11,6 +11,15 @@ set(CPM_SOURCE_CACHE "${CMAKE_SOURCE_DIR}/.cpmsource")
 
 find_package(Threads REQUIRED)
 
+# Find MPI if enabled
+option(DFTRACER_UTILS_ENABLE_MPI "Enable MPI support" OFF)
+if(DFTRACER_UTILS_ENABLE_MPI)
+  find_package(MPI REQUIRED)
+  message(STATUS "MPI support enabled")
+  message(STATUS "  MPI_CXX_COMPILER: ${MPI_CXX_COMPILER}")
+  message(STATUS "  MPI_CXX_LIBRARIES: ${MPI_CXX_LIBRARIES}")
+endif()
+
 set(DEPENDENCY_LIBRARY_DIRS "")
 
 if(CMAKE_VERSION VERSION_LESS 3.18)

--- a/cmake/modules/Rpath.cmake
+++ b/cmake/modules/Rpath.cmake
@@ -15,11 +15,10 @@ macro(add_rpath)
         "@executable_path/../lib64"
         "@executable_path/../../lib64"
         "${DEPENDENCY_LIBRARY_DIRS}")
-    if(SKBUILD)
-      set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-    else()
-      set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
-    endif()
+    # Always use install RPATH in build tree so binaries find
+    # their shared libraries when invoked via popen() or other
+    # contexts where DYLD_LIBRARY_PATH is stripped by SIP.
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
     set(CMAKE_MACOSX_RPATH ON)
   else()
     # Linux uses $ORIGIN

--- a/docs/source/replay.rst
+++ b/docs/source/replay.rst
@@ -1,0 +1,64 @@
+Replay Utility
+==============
+
+The replay utility replays DFTracer trace files by reading recorded events and executing them in a configurable replay mode. It supports plain text and gzipped traces, dry-run analysis, timing-aware replay, and filtered execution for focused testing.
+
+Overview
+--------
+
+The Replay utility is designed to perform the following tasks:
+
+- Parse DFTracer trace files (``.pfw``, ``.pfw.gz``) from one or more files or directories
+- Replay events in dry-run mode for validation without issuing I/O
+- Reproduce event timing or disable timing for faster execution
+- Filter replay by PID, TID, function, category, timestamp range, and operation size
+- Limit replay volume with sampling and maximum event counts
+
+Key Features
+------------
+
+**Multiple Replay Modes**
+  The utility supports dry-run analysis, DFTracer sleep-based replay, and direct event replay. Timing can be preserved or disabled depending on the validation goal.
+
+**Flexible Filtering**
+  Replay can be restricted to selected processes, threads, functions, categories, time windows, and sizes to isolate specific trace behavior.
+
+**Call Tree Integration**
+  The utility can replay traces using the call tree path for hierarchical execution, including optional parent-child ordering constraints.
+
+Replay Modes
+------------
+
+Dry Run
+~~~~~~~
+
+Parses trace events and reports replay statistics without performing the underlying operations.
+
+DFTracer Mode
+~~~~~~~~~~~~~
+
+Simulates replay using operation durations. This is useful for timing-oriented studies without issuing full I/O.
+
+Direct Replay
+~~~~~~~~~~~~~
+
+Executes replay operations directly from the trace stream. This mode is useful when validating end-to-end replay behavior.
+
+Performance Considerations
+--------------------------
+
+**Compressed Traces**
+  Gzipped traces are supported directly. Replay performance depends on trace size and decompression overhead.
+
+**Sampling and Limits**
+  Use sampling and maximum event limits to reduce replay cost for CI, debugging, and exploratory analysis.
+
+**Timing Control**
+  Disabling timing can significantly reduce wall-clock runtime when only correctness or parsing behavior needs to be validated.
+
+See Also
+--------
+
+- :doc:`cli` - Command-line tools
+- :doc:`call-tree` - Call tree utility
+- :doc:`cpp_api/index` - Full C++ API documentation

--- a/include/dftracer/utils/utilities/replay/replay.h
+++ b/include/dftracer/utils/utilities/replay/replay.h
@@ -1,0 +1,334 @@
+#ifndef DFTRACER_UTILS_UTILITIES_REPLAY_REPLAY_H
+#define DFTRACER_UTILS_UTILITIES_REPLAY_REPLAY_H
+
+#include <dftracer/utils/call_tree/call_tree.h>
+#include <dftracer/utils/utilities/reader/internal/line_processor.h>
+#include <dftracer/utils/utilities/reader/internal/reader.h>
+#include <dftracer/utils/utilities/replay/trace.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace dftracer::utils::utilities::replay {
+
+/**
+ * Configuration options for trace replay
+ */
+struct ReplayConfig {
+    // Execution options
+    bool maintain_timing = true;  // Maintain original timing between operations
+    bool dry_run = false;        // Only parse and log operations, don't execute
+    bool dftracer_mode = false;  // Use DFTracer sleep-based replay mode
+    bool no_sleep = false;       // Disable sleep calls in dftracer mode
+    double timing_scale =
+        1.0;  // Scale timing (1.0 = original, 0.5 = 2x faster, 2.0 = 2x slower)
+    std::uint64_t start_time_offset = 0;  // Offset to add to all timestamps
+    bool verbose = false;                 // Verbose logging
+    std::string output_directory;  // Directory for creating files (empty = use
+                                   // original paths)
+    std::size_t max_file_size =
+        1024 * 1024 * 100;         // Max file size to create (100MB default)
+
+    // Function and category filters
+    std::unordered_set<std::string>
+        filter_functions;    // Only replay these functions (empty = all)
+    std::unordered_set<std::string>
+        exclude_functions;   // Exclude these functions
+    std::unordered_set<std::string>
+        filter_categories;   // Only replay these categories
+    std::unordered_set<std::string>
+        exclude_categories;  // Exclude these categories
+
+    // Process/Thread filters
+    std::unordered_set<std::uint32_t>
+        filter_pids;  // Only replay these PIDs (empty = all)
+    std::unordered_set<std::uint32_t>
+        filter_tids;  // Only replay these TIDs (empty = all)
+    std::unordered_set<std::uint32_t> exclude_pids;  // Exclude these PIDs
+    std::unordered_set<std::uint32_t> exclude_tids;  // Exclude these TIDs
+
+    // Timestamp filters (microseconds)
+    std::uint64_t start_timestamp =
+        0;           // Only replay events after this timestamp
+    std::uint64_t end_timestamp =
+        UINT64_MAX;  // Only replay events before this timestamp
+
+    // Operation size filters
+    std::int64_t min_operation_size =
+        -1;  // Only replay operations >= this size
+    std::int64_t max_operation_size =
+        -1;  // Only replay operations <= this size
+
+    // Level/depth filter (for hierarchical traces)
+    int min_level = -1;  // Only replay operations at or above this level
+    int max_level = -1;  // Only replay operations at or below this level
+
+    // Sampling options
+    double sampling_rate = 1.0;        // Replay rate (1.0 = all, 0.1 = 10%)
+    std::uint64_t sample_seed = 0;     // Random seed for sampling
+    bool sample_deterministic = true;  // Use deterministic sampling vs random
+
+    // Resource limits
+    std::size_t max_events = 0;  // Maximum events to replay (0 = unlimited)
+    std::size_t max_open_files = 1024;  // Maximum open file descriptors
+
+    // Call tree options
+    bool use_call_tree =
+        false;  // Use call tree structure for hierarchical replay
+    bool hierarchical_replay =
+        false;  // Replay in hierarchical order (depth-first)
+    bool respect_call_hierarchy =
+        true;   // Respect parent-child relationships in timing
+
+    // MPI options
+    int mpi_rank = 0;  // MPI rank of this process
+    int mpi_size = 1;  // Total number of MPI processes
+};
+
+/**
+ * Results and statistics from replay execution
+ */
+struct ReplayResult {
+    std::size_t total_events = 0;
+    std::size_t executed_events = 0;
+    std::size_t filtered_events = 0;
+    std::size_t failed_events = 0;
+    std::chrono::microseconds total_duration{0};
+    std::chrono::microseconds execution_duration{0};
+    std::unordered_map<std::string, std::size_t> function_counts;
+    std::unordered_map<std::string, std::size_t> category_counts;
+    std::vector<std::string> error_messages;
+
+    // Extended statistics
+    std::unordered_map<std::uint32_t, std::size_t> pid_counts;
+    std::unordered_map<std::uint32_t, std::size_t> tid_counts;
+    std::size_t total_bytes_read = 0;
+    std::size_t total_bytes_written = 0;
+    std::uint64_t first_timestamp = UINT64_MAX;
+    std::uint64_t last_timestamp = 0;
+
+    // Call tree statistics
+    std::size_t total_nodes = 0;
+    std::size_t tree_depth = 0;
+    std::size_t unique_processes = 0;
+
+    /**
+     * Print summary statistics
+     * @param verbose Include detailed breakdown
+     */
+    void print_summary(bool verbose = false) const;
+};
+
+/**
+ * Interface for executing individual trace operations
+ */
+class TraceExecutor {
+   public:
+    virtual ~TraceExecutor() = default;
+
+    /**
+     * Execute a single trace operation
+     * @param trace The parsed trace event
+     * @param config Replay configuration
+     * @return true if successful, false otherwise
+     */
+    virtual bool execute(const Trace& trace, const ReplayConfig& config) = 0;
+
+    /**
+     * Check if this executor can handle the given trace
+     * @param trace The trace event to check
+     * @return true if this executor can handle the trace
+     */
+    virtual bool can_handle(const Trace& trace) const = 0;
+
+    /**
+     * Get human-readable name for this executor
+     */
+    virtual std::string get_name() const = 0;
+};
+
+/**
+ * Executor for POSIX file operations (read, write, open, close, etc.)
+ */
+class PosixExecutor : public TraceExecutor {
+   public:
+    bool execute(const Trace& trace, const ReplayConfig& config) override;
+    bool can_handle(const Trace& trace) const override;
+    std::string get_name() const override { return "POSIX"; }
+
+   private:
+    std::unordered_map<std::string, int> open_files_;
+    int next_fd_ = 1000;
+
+    bool execute_open(const Trace& trace, const ReplayConfig& config);
+    bool execute_close(const Trace& trace, const ReplayConfig& config);
+    bool execute_read(const Trace& trace, const ReplayConfig& config);
+    bool execute_write(const Trace& trace, const ReplayConfig& config);
+    bool execute_seek(const Trace& trace, const ReplayConfig& config);
+    bool execute_stat(const Trace& trace, const ReplayConfig& config);
+};
+
+/**
+ * DFTracer executor for sleep-based replay
+ * Simulates operation timing without actual I/O
+ */
+class DFTracerExecutor : public TraceExecutor {
+   public:
+    bool execute(const Trace& trace, const ReplayConfig& config) override;
+    bool can_handle(const Trace& trace) const override;
+    std::string get_name() const override { return "DFTracer"; }
+
+   private:
+    void sleep_for_duration(double duration_microseconds);
+    bool dftracer_initialized_ = false;
+};
+
+// Forward declaration
+class ReplayLineProcessor;
+
+/**
+ * Main replay engine that coordinates trace reading and execution
+ *
+ * Usage:
+ *   ReplayConfig config;
+ *   config.dftracer_mode = true;
+ *
+ *   ReplayEngine engine(config);
+ *   auto result = engine.replay("trace.pfw.gz");
+ *   result.print_summary();
+ */
+class ReplayEngine {
+    friend class ReplayLineProcessor;
+
+   public:
+    /**
+     * Construct replay engine with configuration
+     * @param config Replay configuration options
+     */
+    explicit ReplayEngine(const ReplayConfig& config);
+
+    /**
+     * Construct and immediately configure for a trace file
+     * @param trace_file Path to trace file
+     * @param config Replay configuration options
+     */
+    ReplayEngine(const std::string& trace_file, const ReplayConfig& config);
+
+    ~ReplayEngine();
+
+    /**
+     * Add a custom executor for specific trace types
+     * @param executor Unique pointer to executor (engine takes ownership)
+     */
+    void add_executor(std::unique_ptr<TraceExecutor> executor);
+
+    /**
+     * Replay traces from a single file
+     * @param trace_file Path to trace file (.pfw or .pfw.gz)
+     * @param index_file Optional path to index file
+     * @return Replay results and statistics
+     */
+    ReplayResult replay(const std::string& trace_file,
+                        const std::string& index_file = "");
+
+    /**
+     * Replay traces from multiple files
+     * @param trace_files Vector of trace file paths
+     * @return Aggregated replay results
+     */
+    ReplayResult replay(const std::vector<std::string>& trace_files);
+
+    /**
+     * Replay traces using call tree structure
+     * Builds hierarchical call tree and replays in proper order
+     * @param trace_dir Directory containing trace files
+     * @param pattern File pattern (default: "*.pfw.gz")
+     * @return Replay results with call tree statistics
+     */
+    ReplayResult replay_with_call_tree(const std::string& trace_dir,
+                                       const std::string& pattern = "*.pfw.gz");
+
+   private:
+    ReplayConfig config_;
+    std::vector<std::unique_ptr<TraceExecutor>> executors_;
+    std::chrono::steady_clock::time_point replay_start_time_;
+    std::uint64_t first_trace_timestamp_ = 0;
+    bool first_timestamp_set_ = false;
+
+    /**
+     * Process a single trace line (JSON)
+     */
+    bool process_trace_line(const std::string& line, ReplayResult& result);
+
+    /**
+     * Parse JSON trace into Trace structure
+     */
+    bool parse_trace_json(const std::string& json_line, Trace& trace);
+
+    /**
+     * Apply timing logic before executing trace
+     */
+    void apply_timing(const Trace& trace);
+
+    /**
+     * Check if trace should be executed based on filters
+     */
+    bool should_execute_trace(const Trace& trace) const;
+
+    /**
+     * Find appropriate executor for trace
+     */
+    TraceExecutor* find_executor(const Trace& trace);
+
+    /**
+     * Get file path for replay (handles output directory override)
+     */
+    std::string get_replay_file_path(const std::string& original_path) const;
+
+    /**
+     * Replay from call tree structure (hierarchical replay)
+     */
+    void replay_from_call_tree(dftracer::utils::call_tree::CallTree& tree,
+                               ReplayResult& result);
+
+    /**
+     * Replay a single call tree node recursively
+     */
+    void replay_call_tree_node_recursive(
+        const dftracer::utils::call_tree::CallTreeNodeInfo& node,
+        dftracer::utils::call_tree::CallTree& call_tree, ReplayResult& result,
+        int depth);
+
+    /**
+     * Replay a single node from call tree
+     */
+    void replay_call_tree_node(
+        const dftracer::utils::call_tree::CallTreeNodeInfo& node,
+        ReplayResult& result);
+};
+
+/**
+ * Line processor for handling trace lines during replay
+ */
+class ReplayLineProcessor
+    : public dftracer::utils::utilities::reader::internal::LineProcessor {
+   public:
+    explicit ReplayLineProcessor(ReplayEngine& engine, ReplayResult& result);
+
+    bool process(const char* data, std::size_t length) override;
+
+   private:
+    ReplayEngine& engine_;
+    ReplayResult& result_;
+};
+
+}  // namespace dftracer::utils::utilities::replay
+
+#endif  // DFTRACER_UTILS_UTILITIES_REPLAY_REPLAY_H

--- a/include/dftracer/utils/utilities/replay/trace.h
+++ b/include/dftracer/utils/utilities/replay/trace.h
@@ -1,0 +1,127 @@
+#ifndef DFTRACER_UTILS_UTILITIES_REPLAY_TRACE_H
+#define DFTRACER_UTILS_UTILITIES_REPLAY_TRACE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace dftracer::utils::utilities::replay {
+
+/**
+ * Enumeration of trace event types
+ */
+enum class TraceType {
+    Regular,          // Normal function call trace
+    FileHash,         // File hash metadata (FH)
+    HostHash,         // Host hash metadata (HH)
+    StringHash,       // String hash metadata
+    ProcessMetadata,  // Process metadata
+    OtherMetadata     // Other metadata types
+};
+
+/**
+ * Type aliases for trace fields
+ */
+using BinFields = std::unordered_map<std::string, std::int32_t>;
+using ViewFields = std::unordered_map<std::string, std::string>;
+
+/**
+ * Trace structure representing a single trace event from DFTracer
+ * Contains all information needed for replay operations
+ */
+struct Trace {
+    // Category and function identification
+    std::string cat;        // Category (e.g., "posix", "stdio", "h5py")
+    std::string io_cat;     // I/O category (read, write, metadata)
+    std::string acc_pat;    // Access pattern
+    std::string func_name;  // Function name (e.g., "read", "write", "open")
+
+    // Timing information
+    double duration;           // Duration in microseconds
+    std::uint64_t count;       // Operation count
+    std::uint64_t time_range;  // Time range
+    std::uint64_t time_start;  // Start timestamp in microseconds
+    std::uint64_t time_end;    // End timestamp in microseconds
+    std::uint64_t epoch;       // Epoch time
+
+    // Process/thread identification
+    std::uint64_t pid;  // Process ID
+    std::uint64_t tid;  // Thread ID
+
+    // File identification
+    std::string fhash;       // File hash
+    std::string hhash;       // Host hash
+    std::uint64_t image_id;  // Image ID
+
+    // Trace type
+    TraceType type;
+
+    // Extended fields for flexible trace data
+    ViewFields view_fields;
+    BinFields bin_fields;
+
+    // I/O operation parameters
+    std::int64_t size = -1;    // Operation size (-1 means unknown)
+    std::int64_t offset = -1;  // File offset (-1 means unknown)
+
+    // Validation flag
+    bool is_valid = false;  // Set after successful parsing
+
+    /**
+     * Default constructor
+     */
+    Trace()
+        : duration(0.0),
+          count(0),
+          time_range(0),
+          time_start(0),
+          time_end(0),
+          epoch(0),
+          pid(0),
+          tid(0),
+          image_id(0),
+          type(TraceType::Regular),
+          size(-1),
+          offset(-1),
+          is_valid(false) {}
+
+    /**
+     * Check if this is a metadata trace
+     */
+    bool is_metadata() const { return type != TraceType::Regular; }
+
+    /**
+     * Get end time, calculating from start + duration if needed
+     */
+    std::uint64_t get_end_time() const {
+        if (time_end > 0) {
+            return time_end;
+        }
+        return time_start + static_cast<std::uint64_t>(duration);
+    }
+
+    /**
+     * Check if this trace has valid timing information
+     */
+    bool has_valid_timing() const {
+        return time_start > 0 && (duration > 0 || time_end > time_start);
+    }
+
+    /**
+     * Check if this trace has I/O size information
+     */
+    bool has_size() const { return size >= 0; }
+
+    /**
+     * Check if this trace has offset information
+     */
+    bool has_offset() const { return offset >= 0; }
+};
+
+}  // namespace dftracer::utils::utilities::replay
+
+#endif  // DFTRACER_UTILS_UTILITIES_REPLAY_TRACE_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,8 @@ set(DFTRACER_UTILS_UTILITIES_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/utilities/call_tree/call_tree.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/utilities/call_tree/call_tree_internal.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/utilities/call_tree/json_serializer.cpp
+    # Replay
+    ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/utilities/replay/replay.cpp
 )
 
 # Add MPI-specific call tree sources if MPI is enabled
@@ -699,6 +701,8 @@ if(DFTRACER_UTILS_BUILD_BINARIES)
       ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/binaries/dftracer_merge.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/binaries/dftracer_split.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/binaries/dftracer_info.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/binaries/dftracer_replay.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/binaries/dftracer_call_tree.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/binaries/dftracer_aggregator.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/binaries/dftracer_index.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/dftracer/utils/binaries/dftracer_gen_fake_trace.cpp

--- a/src/dftracer/utils/binaries/dftracer_call_tree.cpp
+++ b/src/dftracer/utils/binaries/dftracer_call_tree.cpp
@@ -1,0 +1,421 @@
+/**
+ * DFTracer Call Tree Utility
+ * Standalone binary for building and analyzing call trees from DFTracer trace
+ * files
+ */
+
+#include <dftracer/utils/call_tree/call_tree.h>
+#include <dftracer/utils/core/common/config.h>
+#include <dftracer/utils/core/common/filesystem.h>
+#include <dftracer/utils/core/common/logging.h>
+
+#include <algorithm>
+#include <argparse/argparse.hpp>
+#include <chrono>
+#include <cstdio>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace dftracer::utils::call_tree;
+
+/**
+ * Collect trace files from directory or file list
+ */
+std::vector<std::string> collect_trace_files(
+    const std::vector<std::string>& inputs, bool recursive) {
+    std::vector<std::string> trace_files;
+
+    for (const auto& input : inputs) {
+        if (fs::is_directory(input)) {
+            if (recursive) {
+                for (const auto& entry :
+                     fs::recursive_directory_iterator(input)) {
+                    if (entry.is_regular_file()) {
+                        std::string path = entry.path().string();
+                        if ((path.size() >= 4 &&
+                             path.substr(path.size() - 4) == ".pfw") ||
+                            (path.size() >= 7 &&
+                             path.substr(path.size() - 7) == ".pfw.gz")) {
+                            trace_files.push_back(path);
+                        }
+                    }
+                }
+            } else {
+                for (const auto& entry : fs::directory_iterator(input)) {
+                    if (entry.is_regular_file()) {
+                        std::string path = entry.path().string();
+                        if ((path.size() >= 4 &&
+                             path.substr(path.size() - 4) == ".pfw") ||
+                            (path.size() >= 7 &&
+                             path.substr(path.size() - 7) == ".pfw.gz")) {
+                            trace_files.push_back(path);
+                        }
+                    }
+                }
+            }
+        } else if (fs::is_regular_file(input)) {
+            trace_files.push_back(input);
+        } else {
+            DFTRACER_UTILS_LOG_ERROR("Input not found or not accessible: %s",
+                                     input.c_str());
+        }
+    }
+
+    return trace_files;
+}
+
+/**
+ * Analyze call patterns in the tree
+ */
+void analyze_call_patterns(const std::vector<CallTreeNodeInfo>& nodes) {
+    printf("\n--- Call Pattern Analysis ---\n");
+
+    if (nodes.empty()) {
+        printf("No nodes to analyze\n");
+        return;
+    }
+
+    // Find most frequently called functions
+    std::map<std::string, size_t> call_counts;
+    for (const auto& node : nodes) {
+        call_counts[node.name]++;
+    }
+
+    // Sort by frequency
+    std::vector<std::pair<std::string, size_t>> sorted_calls(
+        call_counts.begin(), call_counts.end());
+    std::sort(sorted_calls.begin(), sorted_calls.end(),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+
+    printf("Top 10 most frequently called functions:\n");
+    for (size_t i = 0; i < std::min(sorted_calls.size(), size_t(10)); i++) {
+        printf("  %2zu. %-30s : %zu calls\n", i + 1,
+               sorted_calls[i].first.c_str(), sorted_calls[i].second);
+    }
+}
+
+/**
+ * Analyze timing statistics
+ */
+void analyze_timing(const std::vector<CallTreeNodeInfo>& nodes) {
+    printf("\n--- Timing Analysis ---\n");
+
+    if (nodes.empty()) {
+        printf("No nodes to analyze\n");
+        return;
+    }
+
+    // Calculate timing statistics
+    std::vector<std::uint64_t> durations;
+    durations.reserve(nodes.size());
+
+    for (const auto& node : nodes) {
+        durations.push_back(node.duration_us);
+    }
+
+    std::sort(durations.begin(), durations.end());
+
+    std::uint64_t total = 0;
+    for (auto d : durations) {
+        total += d;
+    }
+    double avg = static_cast<double>(total) / durations.size();
+
+    std::uint64_t min_time = durations.front();
+    std::uint64_t max_time = durations.back();
+    std::uint64_t median = durations[durations.size() / 2];
+    std::uint64_t p95 = durations[static_cast<size_t>(durations.size() * 0.95)];
+    std::uint64_t p99 = durations[static_cast<size_t>(durations.size() * 0.99)];
+
+    printf("Duration statistics (milliseconds):\n");
+    printf("  Min:    %.3f ms\n", min_time / 1000.0);
+    printf("  Max:    %.3f ms\n", max_time / 1000.0);
+    printf("  Mean:   %.3f ms\n", avg / 1000.0);
+    printf("  Median: %.3f ms\n", median / 1000.0);
+    printf("  95th:   %.3f ms\n", p95 / 1000.0);
+    printf("  99th:   %.3f ms\n", p99 / 1000.0);
+}
+
+/**
+ * Find critical path (longest duration calls)
+ */
+void find_critical_path(const std::vector<CallTreeNodeInfo>& nodes) {
+    printf("\n--- Critical Path (Longest Duration Calls) ---\n");
+
+    if (nodes.empty()) {
+        printf("No nodes to analyze\n");
+        return;
+    }
+
+    // Find top 10 longest running calls
+    std::vector<CallTreeNodeInfo> sorted_nodes = nodes;
+    std::sort(sorted_nodes.begin(), sorted_nodes.end(),
+              [](const auto& a, const auto& b) {
+                  return a.duration_us > b.duration_us;
+              });
+
+    printf("Top 10 longest running calls:\n");
+    for (size_t i = 0; i < std::min(sorted_nodes.size(), size_t(10)); i++) {
+        const auto& node = sorted_nodes[i];
+        printf("  %2zu. %-30s [%-15s] - %10.3f ms (level %d)\n", i + 1,
+               node.name.c_str(), node.category.c_str(),
+               node.duration_us / 1000.0, node.level);
+    }
+}
+
+/**
+ * Analyze by category
+ */
+void analyze_by_category(const std::vector<CallTreeNodeInfo>& nodes) {
+    printf("\n--- Analysis by Category ---\n");
+
+    if (nodes.empty()) {
+        printf("No nodes to analyze\n");
+        return;
+    }
+
+    std::map<std::string, size_t> category_counts;
+    std::map<std::string, std::uint64_t> category_durations;
+
+    for (const auto& node : nodes) {
+        category_counts[node.category]++;
+        category_durations[node.category] += node.duration_us;
+    }
+
+    printf("Nodes by category:\n");
+    for (const auto& [category, count] : category_counts) {
+        double avg_duration =
+            static_cast<double>(category_durations[category]) / count / 1000.0;
+        printf("  %-20s: %6zu nodes, avg duration: %.3f ms\n", category.c_str(),
+               count, avg_duration);
+    }
+}
+
+int main(int argc, char** argv) {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    argparse::ArgumentParser program("dftracer_call_tree",
+                                     DFTRACER_UTILS_PACKAGE_VERSION);
+    program.add_description(
+        "DFTracer Call Tree utility - builds and analyzes call trees from "
+        "DFTracer trace files");
+
+    // Input files/directories
+    program.add_argument("inputs")
+        .help(
+            "Trace files (.pfw, .pfw.gz) or directories containing trace files")
+        .nargs(argparse::nargs_pattern::at_least_one);
+
+    // Processing options
+    program.add_argument("-r", "--recursive")
+        .help("Recursively search directories for trace files")
+        .flag();
+
+    program.add_argument("--pattern")
+        .help("File pattern for trace files (default: *.pfw.gz)")
+        .default_value(std::string("*.pfw.gz"));
+
+    // Output options
+    program.add_argument("-o", "--output")
+        .help(
+            "Output file path for serialized call tree (default: "
+            "auto-generated from input)")
+        .default_value(std::string(""));
+
+    program.add_argument("--json")
+        .help("Also save call tree in JSON (Chrome Tracing) format")
+        .flag();
+
+    program.add_argument("--text")
+        .help("Export call tree to text file")
+        .default_value(std::string(""));
+
+    // Analysis options
+    program.add_argument("--max-depth")
+        .help("Maximum depth for tree printing (0=unlimited)")
+        .default_value(0)
+        .scan<'i', int>();
+
+    program.add_argument("--analyze")
+        .help(
+            "Perform detailed analysis (call patterns, timing, critical path)")
+        .flag();
+
+    program.add_argument("-v", "--verbose")
+        .help("Enable verbose output")
+        .flag();
+
+    program.add_argument("--stats-only")
+        .help("Only print statistics, skip tree traversal")
+        .flag();
+
+    program.add_argument("--no-save")
+        .help("Don't save output files, only print analysis")
+        .flag();
+
+    // Parse arguments
+    try {
+        program.parse_args(argc, argv);
+    } catch (const std::exception& err) {
+        std::cerr << err.what() << std::endl;
+        std::cerr << program;
+        return 1;
+    }
+
+    // Get arguments
+    auto inputs = program.get<std::vector<std::string>>("inputs");
+    bool recursive = program.get<bool>("--recursive");
+    std::string pattern = program.get<std::string>("--pattern");
+    std::string output_path = program.get<std::string>("--output");
+    bool save_json = program.get<bool>("--json");
+    std::string text_file = program.get<std::string>("--text");
+    int max_depth = program.get<int>("--max-depth");
+    bool analyze = program.get<bool>("--analyze");
+    bool verbose = program.get<bool>("--verbose");
+    bool stats_only = program.get<bool>("--stats-only");
+    bool no_save = program.get<bool>("--no-save");
+
+    // Collect trace files
+    printf("=== DFTracer Call Tree Builder ===\n\n");
+
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    // For single directory input, use load_from_directory
+    // For multiple inputs or files, collect manually
+    CallTree tree;
+    bool loaded = false;
+
+    if (inputs.size() == 1 && fs::is_directory(inputs[0])) {
+        printf("Loading traces from directory: %s\n", inputs[0].c_str());
+        if (verbose) {
+            printf("  Pattern: %s\n", pattern.c_str());
+            printf("  Recursive: %s\n", recursive ? "yes" : "no");
+        }
+
+        loaded = tree.load_from_directory(inputs[0], pattern);
+        if (!loaded) {
+            fprintf(stderr, "Failed to load traces from directory: %s\n",
+                    inputs[0].c_str());
+            return 1;
+        }
+    } else {
+        auto trace_files = collect_trace_files(inputs, recursive);
+        if (trace_files.empty()) {
+            fprintf(stderr, "No trace files found in the specified inputs.\n");
+            return 1;
+        }
+
+        printf("Found %zu trace file(s) to process:\n", trace_files.size());
+        if (verbose) {
+            for (const auto& file : trace_files) {
+                printf("  %s\n", file.c_str());
+            }
+        }
+
+        // Load first directory for now (CallTree API expects directory)
+        // This is a limitation of the current API
+        fprintf(stderr,
+                "Note: Multi-file input not yet supported. Use directory input "
+                "instead.\n");
+        return 1;
+    }
+
+    printf("Loaded %zu trace files\n", tree.get_num_trace_files());
+    printf("\n");
+
+    // Generate call tree
+    printf("Generating call tree structure...\n");
+    if (!tree.generate()) {
+        fprintf(stderr, "Failed to generate call tree\n");
+        return 1;
+    }
+    printf("Call tree generation complete\n\n");
+
+    auto gen_time = std::chrono::high_resolution_clock::now();
+    auto gen_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+        gen_time - start_time);
+    if (verbose) {
+        printf("Generation time: %ld ms\n\n", gen_duration.count());
+    }
+
+    // Print statistics
+    printf("=== Call Tree Statistics ===\n");
+    tree.print_statistics();
+
+    // Print tree structure
+    if (!stats_only) {
+        printf("\n=== Call Tree Structure ===\n");
+        tree.print_depth_first(max_depth);
+    }
+
+    // Perform detailed analysis if requested
+    if (analyze) {
+        printf("\n=== Detailed Analysis ===\n");
+        auto nodes = tree.get_nodes_depth_first();
+        printf("Retrieved %zu nodes for analysis\n", nodes.size());
+
+        analyze_call_patterns(nodes);
+        analyze_timing(nodes);
+        find_critical_path(nodes);
+        analyze_by_category(nodes);
+    }
+
+    // Save outputs
+    if (!no_save) {
+        printf("\n=== Saving Outputs ===\n");
+
+        // Set custom output path if specified
+        if (!output_path.empty()) {
+            tree.set_output_path(output_path);
+        }
+
+        // Save binary format
+        std::string bin_file = tree.get_output_path();
+        printf("Saving binary call tree to: %s\n", bin_file.c_str());
+        if (tree.save_to_file()) {
+            printf("  Successfully saved!\n");
+        } else {
+            fprintf(stderr, "  Failed to save binary file\n");
+        }
+
+        // Save JSON format if requested
+        if (save_json) {
+            std::string json_file = bin_file;
+            // Replace .calltree extension with .pfw
+            if (json_file.size() >= 9 &&
+                json_file.substr(json_file.size() - 9) == ".calltree") {
+                json_file = json_file.substr(0, json_file.size() - 9) + ".pfw";
+            } else {
+                json_file += ".pfw";
+            }
+
+            printf("Saving JSON call tree to: %s\n", json_file.c_str());
+            if (tree.save_to_json(json_file)) {
+                printf("  Successfully saved! (Chrome Tracing compatible)\n");
+            } else {
+                fprintf(stderr, "  Failed to save JSON file\n");
+            }
+        }
+
+        // Save text format if requested
+        if (!text_file.empty()) {
+            printf("Exporting call tree to text file: %s\n", text_file.c_str());
+            if (tree.print_depth_first_to_file(text_file, max_depth)) {
+                printf("  Successfully exported!\n");
+            } else {
+                fprintf(stderr, "  Failed to export text file\n");
+            }
+        }
+    }
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+    auto total_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    printf("\n=== Completed ===\n");
+    printf("Total execution time: %ld ms\n", total_duration.count());
+
+    return 0;
+}

--- a/src/dftracer/utils/binaries/dftracer_replay.cpp
+++ b/src/dftracer/utils/binaries/dftracer_replay.cpp
@@ -1,0 +1,558 @@
+#include <dftracer/utils/core/common/config.h>
+#include <dftracer/utils/core/common/filesystem.h>
+#include <dftracer/utils/core/common/logging.h>
+#include <dftracer/utils/core/mpi/mpi_utils.h>
+#include <dftracer/utils/utilities/replay/replay.h>
+
+#include <argparse/argparse.hpp>
+
+#ifdef DFTRACER_UTILS_MPI_ENABLED
+#include <mpi.h>
+#endif
+
+#include <chrono>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+using namespace dftracer::utils;
+using namespace dftracer::utils::utilities::replay;
+
+/**
+ * Collect trace files from directory or file list
+ */
+std::vector<std::string> collect_trace_files(
+    const std::vector<std::string>& inputs, bool recursive) {
+    std::vector<std::string> trace_files;
+
+    for (const auto& input : inputs) {
+        if (fs::is_directory(input)) {
+            if (recursive) {
+                for (const auto& entry :
+                     fs::recursive_directory_iterator(input)) {
+                    if (entry.is_regular_file()) {
+                        std::string path = entry.path().string();
+                        if ((path.size() >= 4 &&
+                             path.substr(path.size() - 4) == ".pfw") ||
+                            (path.size() >= 7 &&
+                             path.substr(path.size() - 7) == ".pfw.gz")) {
+                            trace_files.push_back(path);
+                        }
+                    }
+                }
+            } else {
+                for (const auto& entry : fs::directory_iterator(input)) {
+                    if (entry.is_regular_file()) {
+                        std::string path = entry.path().string();
+                        if ((path.size() >= 4 &&
+                             path.substr(path.size() - 4) == ".pfw") ||
+                            (path.size() >= 7 &&
+                             path.substr(path.size() - 7) == ".pfw.gz")) {
+                            trace_files.push_back(path);
+                        }
+                    }
+                }
+            }
+        } else if (fs::is_regular_file(input)) {
+            trace_files.push_back(input);
+        } else {
+            DFTRACER_UTILS_LOG_ERROR("Input not found or not accessible: %s",
+                                     input.c_str());
+        }
+    }
+
+    return trace_files;
+}
+
+int main(int argc, char** argv) {
+#ifdef DFTRACER_UTILS_MPI_ENABLED
+    MPI_Init(&argc, &argv);
+    mpi::MPIUtils::instance().initialize();
+#endif
+
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    // Get MPI rank for output control (defaults to rank 0, size 1 without MPI)
+    int mpi_rank = 0;
+    int mpi_size = 1;
+    bool is_root = true;
+#ifdef DFTRACER_UTILS_MPI_ENABLED
+    mpi_rank = mpi::MPIUtils::instance().get_rank();
+    mpi_size = mpi::MPIUtils::instance().get_world_size();
+    is_root = mpi::MPIUtils::instance().is_root();
+#endif
+
+    argparse::ArgumentParser program("dftracer_replay",
+                                     DFTRACER_UTILS_PACKAGE_VERSION);
+    program.add_description(
+        "DFTracer replay utility - replays I/O operations from DFTracer trace "
+        "files (.pfw, .pfw.gz)");
+
+    // Input files/directories
+    program.add_argument("inputs")
+        .help(
+            "Trace files (.pfw, .pfw.gz) or directories containing trace files")
+        .nargs(argparse::nargs_pattern::at_least_one);
+
+    // Timing options
+    program.add_argument("--no-timing")
+        .help("Ignore original timing and execute as fast as possible")
+        .flag();
+
+    // Execution options
+    program.add_argument("--dry-run")
+        .help("Parse and analyze traces without executing operations")
+        .flag();
+
+    program.add_argument("--dftracer-mode")
+        .help(
+            "Use DFTracer sleep-based replay (sleep for operation duration "
+            "instead of doing actual I/O)")
+        .flag();
+
+    program.add_argument("--no-sleep")
+        .help(
+            "When used with --dftracer-mode, disable sleep calls for maximum "
+            "speed")
+        .flag();
+
+    program.add_argument("--verbose")
+        .help("Enable verbose output and detailed statistics")
+        .flag();
+
+    program.add_argument("-r", "--recursive")
+        .help("Recursively search directories for trace files")
+        .flag();
+
+    // Call tree options
+    program.add_argument("--use-call-tree")
+        .help("Build and use call tree structure for hierarchical replay")
+        .flag();
+
+    program.add_argument("--hierarchical-replay")
+        .help(
+            "Replay operations respecting parent-child call hierarchy "
+            "(requires --use-call-tree)")
+        .flag();
+
+    program.add_argument("--respect-call-hierarchy")
+        .help(
+            "Replay child nodes immediately after parent (requires "
+            "--use-call-tree and --hierarchical-replay)")
+        .flag();
+
+    // Filtering options - Process/Thread
+    program.add_argument("--filter-pid")
+        .help("Only replay events from specific PID(s) (comma-separated)")
+        .default_value(std::string(""));
+
+    program.add_argument("--exclude-pid")
+        .help("Exclude events from specific PID(s) (comma-separated)")
+        .default_value(std::string(""));
+
+    program.add_argument("--filter-tid")
+        .help("Only replay events from specific TID(s) (comma-separated)")
+        .default_value(std::string(""));
+
+    program.add_argument("--exclude-tid")
+        .help("Exclude events from specific TID(s) (comma-separated)")
+        .default_value(std::string(""));
+
+    // Filtering options - Function/Category
+    program.add_argument("--filter-function")
+        .help(
+            "Only replay specific function(s) (comma-separated, e.g., "
+            "'read,write,open')")
+        .default_value(std::string(""));
+
+    program.add_argument("--exclude-function")
+        .help("Exclude specific function(s) (comma-separated)")
+        .default_value(std::string(""));
+
+    program.add_argument("--filter-category")
+        .help(
+            "Only replay specific category/categories (comma-separated, e.g., "
+            "'POSIX,storage')")
+        .default_value(std::string(""));
+
+    program.add_argument("--exclude-category")
+        .help("Exclude specific category/categories (comma-separated)")
+        .default_value(std::string(""));
+
+    // Filtering options - Timestamp
+    program.add_argument("--start-timestamp")
+        .help("Only replay events after this timestamp (microseconds)")
+        .default_value(std::uint64_t(0))
+        .scan<'u', std::uint64_t>();
+
+    program.add_argument("--end-timestamp")
+        .help("Only replay events before this timestamp (microseconds)")
+        .default_value(UINT64_MAX)
+        .scan<'u', std::uint64_t>();
+
+    // Filtering options - Size
+    program.add_argument("--min-size")
+        .help("Only replay operations with size >= this value (bytes)")
+        .default_value(std::int64_t(-1))
+        .scan<'i', std::int64_t>();
+
+    program.add_argument("--max-size")
+        .help("Only replay operations with size <= this value (bytes)")
+        .default_value(std::int64_t(-1))
+        .scan<'i', std::int64_t>();
+
+    // Sampling options
+    program.add_argument("--sample-rate")
+        .help("Sample rate for replay (0.0-1.0, 1.0=all events, 0.1=10%)")
+        .default_value(1.0)
+        .scan<'g', double>();
+
+    program.add_argument("--sample-seed")
+        .help("Random seed for sampling (for reproducibility)")
+        .default_value(std::uint64_t(0))
+        .scan<'u', std::uint64_t>();
+
+    // Resource limits
+    program.add_argument("--max-events")
+        .help("Maximum number of events to replay (0=unlimited)")
+        .default_value(std::size_t(0))
+        .scan<'u', std::size_t>();
+
+    try {
+        program.parse_args(argc, argv);
+    } catch (const std::exception& err) {
+        DFTRACER_UTILS_LOG_ERROR("Argument parsing error: %s", err.what());
+        std::cerr << program;
+        return 1;
+    }
+
+    // Helper to parse comma-separated values
+    auto parse_csv_uint32 =
+        [](const std::string& csv) -> std::unordered_set<std::uint32_t> {
+        std::unordered_set<std::uint32_t> result;
+        if (csv.empty()) return result;
+
+        std::istringstream ss(csv);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            if (!token.empty()) {
+                result.insert(std::stoul(token));
+            }
+        }
+        return result;
+    };
+
+    auto parse_csv_string =
+        [](const std::string& csv) -> std::unordered_set<std::string> {
+        std::unordered_set<std::string> result;
+        if (csv.empty()) return result;
+
+        std::istringstream ss(csv);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            if (!token.empty()) {
+                result.insert(token);
+            }
+        }
+        return result;
+    };
+
+    // Parse arguments
+    std::vector<std::string> inputs =
+        program.get<std::vector<std::string>>("inputs");
+    bool no_timing = program.get<bool>("--no-timing");
+    bool dry_run = program.get<bool>("--dry-run");
+    bool dftracer_mode = program.get<bool>("--dftracer-mode");
+    bool no_sleep = program.get<bool>("--no-sleep");
+    bool verbose = program.get<bool>("--verbose");
+    bool recursive = program.get<bool>("--recursive");
+
+    // Call tree options
+    bool use_call_tree = program.get<bool>("--use-call-tree");
+    bool hierarchical_replay = program.get<bool>("--hierarchical-replay");
+    bool respect_call_hierarchy = program.get<bool>("--respect-call-hierarchy");
+
+    // Parse filter arguments
+    auto filter_pids =
+        parse_csv_uint32(program.get<std::string>("--filter-pid"));
+    auto exclude_pids =
+        parse_csv_uint32(program.get<std::string>("--exclude-pid"));
+    auto filter_tids =
+        parse_csv_uint32(program.get<std::string>("--filter-tid"));
+    auto exclude_tids =
+        parse_csv_uint32(program.get<std::string>("--exclude-tid"));
+    auto filter_functions =
+        parse_csv_string(program.get<std::string>("--filter-function"));
+    auto exclude_functions =
+        parse_csv_string(program.get<std::string>("--exclude-function"));
+    auto filter_categories =
+        parse_csv_string(program.get<std::string>("--filter-category"));
+    auto exclude_categories =
+        parse_csv_string(program.get<std::string>("--exclude-category"));
+
+    std::uint64_t start_timestamp =
+        program.get<std::uint64_t>("--start-timestamp");
+    std::uint64_t end_timestamp = program.get<std::uint64_t>("--end-timestamp");
+    std::int64_t min_size = program.get<std::int64_t>("--min-size");
+    std::int64_t max_size = program.get<std::int64_t>("--max-size");
+    double sample_rate = program.get<double>("--sample-rate");
+    std::uint64_t sample_seed = program.get<std::uint64_t>("--sample-seed");
+    std::size_t max_events = program.get<std::size_t>("--max-events");
+
+    // Validate --no-sleep usage
+    if (no_sleep && !dftracer_mode) {
+        std::cerr << "Error: --no-sleep can only be used with --dftracer-mode"
+                  << std::endl;
+        return 1;
+    }
+
+    // Validate call tree options
+    if (hierarchical_replay && !use_call_tree) {
+        std::cerr << "Error: --hierarchical-replay requires --use-call-tree"
+                  << std::endl;
+        return 1;
+    }
+
+    if (respect_call_hierarchy && !hierarchical_replay) {
+        std::cerr
+            << "Error: --respect-call-hierarchy requires --hierarchical-replay"
+            << std::endl;
+        return 1;
+    }
+
+    // Validate sample rate
+    if (sample_rate < 0.0 || sample_rate > 1.0) {
+        std::cerr << "Error: --sample-rate must be between 0.0 and 1.0"
+                  << std::endl;
+        return 1;
+    }
+
+    // Collect trace files
+    std::vector<std::string> trace_files =
+        collect_trace_files(inputs, recursive);
+
+    if (trace_files.empty()) {
+        if (is_root)
+            std::cerr << "No trace files found in the specified inputs."
+                      << std::endl;
+#ifdef DFTRACER_UTILS_MPI_ENABLED
+        mpi::MPIUtils::instance().finalize();
+        MPI_Finalize();
+#endif
+        return 1;
+    }
+
+    if (is_root) {
+        std::cout << "Found " << trace_files.size()
+                  << " trace file(s) to replay:" << std::endl;
+        for (const auto& file : trace_files) {
+            std::cout << "  " << file << std::endl;
+        }
+    }
+
+    // Configure replay
+    ReplayConfig config;
+    config.maintain_timing = !no_timing;
+    config.dry_run = dry_run;
+    config.dftracer_mode = dftracer_mode;
+    config.no_sleep = no_sleep;
+    config.verbose = verbose;
+
+    // Store MPI info in config
+    config.mpi_rank = mpi_rank;
+    config.mpi_size = mpi_size;
+
+    // Call tree options
+    config.use_call_tree = use_call_tree;
+    config.hierarchical_replay = hierarchical_replay;
+    config.respect_call_hierarchy = respect_call_hierarchy;
+
+    // Apply filters
+    config.filter_pids = filter_pids;
+    config.exclude_pids = exclude_pids;
+    config.filter_tids = filter_tids;
+    config.exclude_tids = exclude_tids;
+    config.filter_functions = filter_functions;
+    config.exclude_functions = exclude_functions;
+    config.filter_categories = filter_categories;
+    config.exclude_categories = exclude_categories;
+
+    // Apply ranges and limits
+    config.start_timestamp = start_timestamp;
+    config.end_timestamp = end_timestamp;
+    config.min_operation_size = min_size;
+    config.max_operation_size = max_size;
+    config.sampling_rate = sample_rate;
+    config.sample_seed = sample_seed;
+    config.max_events = max_events;
+
+    // Print configuration (only on rank 0)
+    if (is_root) {
+        std::cout << "\n=== Replay Configuration ===" << std::endl;
+        if (mpi_size > 1) {
+            std::cout << "MPI processes: " << mpi_size << std::endl;
+        }
+        std::cout << "Maintain timing: "
+                  << (config.maintain_timing ? "yes" : "no") << std::endl;
+        std::cout << "Dry run: " << (config.dry_run ? "yes" : "no")
+                  << std::endl;
+        if (config.dftracer_mode) {
+            std::cout << "DFTracer mode: yes ("
+                      << (config.no_sleep ? "no-sleep" : "sleep-based") << ")"
+                      << std::endl;
+        } else {
+            std::cout << "DFTracer mode: no (actual I/O)" << std::endl;
+        }
+        if (config.use_call_tree) {
+            std::cout << "Call tree mode: yes" << std::endl;
+            std::cout << "  Hierarchical replay: "
+                      << (config.hierarchical_replay ? "yes" : "no")
+                      << std::endl;
+            if (config.hierarchical_replay) {
+                std::cout << "  Respect call hierarchy: "
+                          << (config.respect_call_hierarchy ? "yes" : "no")
+                          << std::endl;
+            }
+        }
+    }
+    // Print active filters
+    // Print active filters (only on rank 0)
+    if (is_root &&
+        (!filter_pids.empty() || !exclude_pids.empty() ||
+         !filter_tids.empty() || !exclude_tids.empty() ||
+         !filter_functions.empty() || !exclude_functions.empty() ||
+         !filter_categories.empty() || !exclude_categories.empty() ||
+         start_timestamp > 0 || end_timestamp < UINT64_MAX || min_size >= 0 ||
+         max_size >= 0 || sample_rate < 1.0 || max_events > 0)) {
+        std::cout << "\nActive Filters:" << std::endl;
+        if (!filter_pids.empty()) {
+            std::cout << "  Filter PIDs: ";
+            for (auto pid : filter_pids) std::cout << pid << " ";
+            std::cout << std::endl;
+        }
+        if (!exclude_pids.empty()) {
+            std::cout << "  Exclude PIDs: ";
+            for (auto pid : exclude_pids) std::cout << pid << " ";
+            std::cout << std::endl;
+        }
+        if (!filter_tids.empty()) {
+            std::cout << "  Filter TIDs: ";
+            for (auto tid : filter_tids) std::cout << tid << " ";
+            std::cout << std::endl;
+        }
+        if (!exclude_tids.empty()) {
+            std::cout << "  Exclude TIDs: ";
+            for (auto tid : exclude_tids) std::cout << tid << " ";
+            std::cout << std::endl;
+        }
+        if (!filter_functions.empty()) {
+            std::cout << "  Filter functions: ";
+            for (const auto& f : filter_functions) std::cout << f << " ";
+            std::cout << std::endl;
+        }
+        if (!exclude_functions.empty()) {
+            std::cout << "  Exclude functions: ";
+            for (const auto& f : exclude_functions) std::cout << f << " ";
+            std::cout << std::endl;
+        }
+        if (!filter_categories.empty()) {
+            std::cout << "  Filter categories: ";
+            for (const auto& c : filter_categories) std::cout << c << " ";
+            std::cout << std::endl;
+        }
+        if (!exclude_categories.empty()) {
+            std::cout << "  Exclude categories: ";
+            for (const auto& c : exclude_categories) std::cout << c << " ";
+            std::cout << std::endl;
+        }
+        if (start_timestamp > 0) {
+            std::cout << "  Start timestamp: " << start_timestamp << std::endl;
+        }
+        if (end_timestamp < UINT64_MAX) {
+            std::cout << "  End timestamp: " << end_timestamp << std::endl;
+        }
+        if (min_size >= 0) {
+            std::cout << "  Min operation size: " << min_size << " bytes"
+                      << std::endl;
+        }
+        if (max_size >= 0) {
+            std::cout << "  Max operation size: " << max_size << " bytes"
+                      << std::endl;
+        }
+        if (sample_rate < 1.0) {
+            std::cout << "  Sampling rate: " << (sample_rate * 100.0) << "%"
+                      << std::endl;
+        }
+        if (max_events > 0) {
+            std::cout << "  Max events: " << max_events << std::endl;
+        }
+    }
+
+    // Create replay engine and execute
+    if (is_root) std::cout << "\n=== Starting Replay ===" << std::endl;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    ReplayEngine engine(config);
+    ReplayResult result;
+
+    if (use_call_tree) {
+        // Call tree mode: expects a single directory containing trace files
+        if (inputs.size() != 1 || !fs::is_directory(inputs[0])) {
+            if (is_root)
+                std::cerr << "Error: --use-call-tree requires exactly one "
+                             "input directory"
+                          << std::endl;
+#ifdef DFTRACER_UTILS_MPI_ENABLED
+            mpi::MPIUtils::instance().finalize();
+            MPI_Finalize();
+#endif
+            return 1;
+        }
+        if (is_root)
+            std::cout << "Using call tree hierarchical replay mode"
+                      << std::endl;
+        result = engine.replay_with_call_tree(inputs[0]);
+    } else {
+        // Normal mode: replay trace files directly
+        result = engine.replay(trace_files);
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto total_wall_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(end_time -
+                                                              start_time);
+
+    if (is_root) {
+        std::cout << "\n=== Replay Completed ===" << std::endl;
+        std::cout << "Wall clock time: "
+                  << static_cast<double>(total_wall_time.count()) / 1000.0
+                  << " ms" << std::endl;
+
+        // Print results
+        result.print_summary(verbose);
+    }
+
+    // Return appropriate exit code
+    int exit_code = 0;
+    if (result.failed_events > 0) {
+        if (is_root)
+            std::cout << "\nReplay completed with errors." << std::endl;
+        exit_code = 2;
+    } else if (result.executed_events > 0) {
+        if (is_root)
+            std::cout << "\nReplay completed successfully." << std::endl;
+        exit_code = 0;
+    } else {
+        if (is_root) std::cout << "\nNo events were executed." << std::endl;
+        exit_code = 1;
+    }
+
+#ifdef DFTRACER_UTILS_MPI_ENABLED
+    mpi::MPIUtils::instance().finalize();
+    MPI_Finalize();
+#endif
+
+    return exit_code;
+}

--- a/src/dftracer/utils/utilities/replay/replay.cpp
+++ b/src/dftracer/utils/utilities/replay/replay.cpp
@@ -1,0 +1,1206 @@
+#include <dftracer/utils/call_tree/call_tree.h>
+#include <dftracer/utils/core/common/filesystem.h>
+#include <dftracer/utils/core/common/logging.h>
+#include <dftracer/utils/utilities/composites/dft/internal/utils.h>
+#include <dftracer/utils/utilities/indexer/internal/indexer.h>
+#include <dftracer/utils/utilities/reader/internal/reader_factory.h>
+#include <dftracer/utils/utilities/replay/replay.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <yyjson.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <thread>
+
+namespace dftracer::utils::utilities::replay {
+
+namespace {
+
+/**
+ * Trim whitespace and validate JSON string
+ */
+bool json_trim_and_validate(const char* input, std::size_t input_length,
+                            const char*& trimmed, std::size_t& trimmed_length) {
+    if (!input || input_length == 0) {
+        return false;
+    }
+
+    // Trim leading whitespace
+    std::size_t start = 0;
+    while (start < input_length &&
+           (input[start] == ' ' || input[start] == '\t' ||
+            input[start] == '\n' || input[start] == '\r')) {
+        start++;
+    }
+
+    // Trim trailing whitespace and comma
+    std::size_t end = input_length;
+    while (end > start && (input[end - 1] == ' ' || input[end - 1] == '\t' ||
+                           input[end - 1] == '\n' || input[end - 1] == '\r' ||
+                           input[end - 1] == ',')) {
+        end--;
+    }
+
+    if (start >= end) {
+        return false;
+    }
+
+    trimmed = input + start;
+    trimmed_length = end - start;
+
+    // Basic validation: must start with '{' and end with '}'
+    if (trimmed[0] != '{' || trimmed[trimmed_length - 1] != '}') {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Parse a JSON string value from yyjson
+ */
+std::string get_json_string(yyjson_val* val, const char* key,
+                            const std::string& default_value = "") {
+    yyjson_val* field = yyjson_obj_get(val, key);
+    if (field && yyjson_is_str(field)) {
+        return yyjson_get_str(field);
+    }
+    return default_value;
+}
+
+/**
+ * Parse a JSON uint64 value from yyjson
+ */
+std::uint64_t get_json_uint64(yyjson_val* val, const char* key,
+                              std::uint64_t default_value = 0) {
+    yyjson_val* field = yyjson_obj_get(val, key);
+    if (field && yyjson_is_uint(field)) {
+        return yyjson_get_uint(field);
+    } else if (field && yyjson_is_int(field)) {
+        std::int64_t int_val = yyjson_get_int(field);
+        return int_val >= 0 ? static_cast<std::uint64_t>(int_val)
+                            : default_value;
+    }
+    return default_value;
+}
+
+/**
+ * Parse a JSON double value from yyjson
+ */
+double get_json_double(yyjson_val* val, const char* key,
+                       double default_value = 0.0) {
+    yyjson_val* field = yyjson_obj_get(val, key);
+    if (field && yyjson_is_real(field)) {
+        return yyjson_get_real(field);
+    } else if (field && yyjson_is_uint(field)) {
+        return static_cast<double>(yyjson_get_uint(field));
+    } else if (field && yyjson_is_int(field)) {
+        return static_cast<double>(yyjson_get_int(field));
+    }
+    return default_value;
+}
+
+/**
+ * Get a string value from args object
+ */
+std::string get_args_string(yyjson_val* root, const char* key,
+                            const std::string& default_value = "") {
+    yyjson_val* args = yyjson_obj_get(root, "args");
+    if (args && yyjson_is_obj(args)) {
+        return get_json_string(args, key, default_value);
+    }
+    return default_value;
+}
+
+/**
+ * Get a uint64 value from args object
+ */
+std::uint64_t get_args_uint64(yyjson_val* root, const char* key,
+                              std::uint64_t default_value = 0) {
+    yyjson_val* args = yyjson_obj_get(root, "args");
+    if (args && yyjson_is_obj(args)) {
+        return get_json_uint64(args, key, default_value);
+    }
+    return default_value;
+}
+
+/**
+ * Get an int64 value from args object
+ */
+std::int64_t get_args_int64(yyjson_val* root, const char* key,
+                            std::int64_t default_value = 0) {
+    yyjson_val* args = yyjson_obj_get(root, "args");
+    if (args && yyjson_is_obj(args)) {
+        yyjson_val* field = yyjson_obj_get(args, key);
+        if (field && yyjson_is_int(field)) {
+            return yyjson_get_int(field);
+        } else if (field && yyjson_is_uint(field)) {
+            return static_cast<std::int64_t>(yyjson_get_uint(field));
+        }
+    }
+    return default_value;
+}
+
+/**
+ * Create directory path if it doesn't exist
+ */
+bool ensure_directory_exists(const std::string& path) {
+    std::string dir_path = path.substr(0, path.find_last_of('/'));
+    if (dir_path.empty() || dir_path == path) return true;
+
+    struct stat st;
+    if (stat(dir_path.c_str(), &st) == 0) {
+        return S_ISDIR(st.st_mode);
+    }
+
+    // Try to create directory recursively
+    return ensure_directory_exists(dir_path) &&
+           (mkdir(dir_path.c_str(), 0755) == 0);
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// PosixExecutor Implementation
+// =============================================================================
+
+bool PosixExecutor::execute(const Trace& trace, const ReplayConfig& config) {
+    const std::string& func_name = trace.func_name;
+
+    if (config.dry_run) {
+        DFTRACER_UTILS_LOG_DEBUG("DRY RUN: Would execute POSIX %s",
+                                 func_name.c_str());
+        return true;
+    }
+
+    if (func_name == "open" || func_name == "open64" || func_name == "openat") {
+        return execute_open(trace, config);
+    } else if (func_name == "close") {
+        return execute_close(trace, config);
+    } else if (func_name == "read" || func_name == "pread" ||
+               func_name == "pread64") {
+        return execute_read(trace, config);
+    } else if (func_name == "write" || func_name == "pwrite" ||
+               func_name == "pwrite64") {
+        return execute_write(trace, config);
+    } else if (func_name == "lseek" || func_name == "lseek64") {
+        return execute_seek(trace, config);
+    } else if (func_name == "stat" || func_name == "stat64" ||
+               func_name == "lstat" || func_name == "fstat") {
+        return execute_stat(trace, config);
+    }
+
+    DFTRACER_UTILS_LOG_DEBUG("Unsupported POSIX function: %s",
+                             func_name.c_str());
+    return false;
+}
+
+bool PosixExecutor::can_handle(const Trace& trace) const {
+    return trace.cat == "posix" || trace.cat == "POSIX";
+}
+
+bool PosixExecutor::execute_open(const Trace& trace,
+                                 const ReplayConfig& config) {
+    DFTRACER_UTILS_LOG_DEBUG("Executing POSIX open");
+
+    if (!trace.fhash.empty()) {
+        std::string file_path =
+            config.output_directory.empty()
+                ? ("replay_file_" + trace.fhash)
+                : (config.output_directory + "/replay_file_" + trace.fhash);
+
+        ensure_directory_exists(file_path);
+
+        int fd = open(file_path.c_str(), O_CREAT | O_RDWR, 0644);
+        if (fd >= 0) {
+            open_files_[trace.fhash] = fd;
+            DFTRACER_UTILS_LOG_DEBUG("Opened file %s with fd %d",
+                                     file_path.c_str(), fd);
+            return true;
+        } else {
+            DFTRACER_UTILS_LOG_ERROR("Failed to open file %s: %s",
+                                     file_path.c_str(), strerror(errno));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool PosixExecutor::execute_close(const Trace& trace,
+                                  [[maybe_unused]] const ReplayConfig& config) {
+    DFTRACER_UTILS_LOG_DEBUG("Executing POSIX close");
+
+    auto it = open_files_.find(trace.fhash);
+    if (it != open_files_.end()) {
+        close(it->second);
+        open_files_.erase(it);
+        DFTRACER_UTILS_LOG_DEBUG("Closed file with hash %s",
+                                 trace.fhash.c_str());
+    }
+
+    return true;
+}
+
+bool PosixExecutor::execute_read(const Trace& trace,
+                                 const ReplayConfig& config) {
+    DFTRACER_UTILS_LOG_DEBUG("Executing POSIX read (size: %lld)",
+                             static_cast<long long>(trace.size));
+
+    auto it = open_files_.find(trace.fhash);
+    if (it != open_files_.end() && trace.size > 0) {
+        std::vector<char> buffer(std::min(static_cast<std::size_t>(trace.size),
+                                          config.max_file_size));
+        ssize_t bytes_read = read(it->second, buffer.data(), buffer.size());
+        DFTRACER_UTILS_LOG_DEBUG("Read %zd bytes", bytes_read);
+    }
+
+    return true;
+}
+
+bool PosixExecutor::execute_write(const Trace& trace,
+                                  const ReplayConfig& config) {
+    DFTRACER_UTILS_LOG_DEBUG("Executing POSIX write (size: %lld)",
+                             static_cast<long long>(trace.size));
+
+    auto it = open_files_.find(trace.fhash);
+    if (it != open_files_.end() && trace.size > 0) {
+        std::size_t write_size = std::min(static_cast<std::size_t>(trace.size),
+                                          config.max_file_size);
+        std::vector<char> buffer(write_size, 'A');
+        ssize_t bytes_written = write(it->second, buffer.data(), buffer.size());
+        DFTRACER_UTILS_LOG_DEBUG("Wrote %zd bytes", bytes_written);
+    }
+
+    return true;
+}
+
+bool PosixExecutor::execute_seek(const Trace& trace,
+                                 [[maybe_unused]] const ReplayConfig& config) {
+    DFTRACER_UTILS_LOG_DEBUG("Executing POSIX seek (offset: %lld)",
+                             static_cast<long long>(trace.offset));
+
+    auto it = open_files_.find(trace.fhash);
+    if (it != open_files_.end() && trace.offset >= 0) {
+        off_t result = lseek(it->second, trace.offset, SEEK_SET);
+        DFTRACER_UTILS_LOG_DEBUG("Seek to offset %lld, result: %lld",
+                                 static_cast<long long>(trace.offset),
+                                 static_cast<long long>(result));
+    }
+
+    return true;
+}
+
+bool PosixExecutor::execute_stat([[maybe_unused]] const Trace& trace,
+                                 [[maybe_unused]] const ReplayConfig& config) {
+    DFTRACER_UTILS_LOG_DEBUG("Executing POSIX stat");
+
+    if (!trace.fhash.empty()) {
+        DFTRACER_UTILS_LOG_DEBUG("Would stat file with hash %s",
+                                 trace.fhash.c_str());
+    }
+
+    return true;
+}
+
+// =============================================================================
+// DFTracerExecutor Implementation
+// =============================================================================
+
+bool DFTracerExecutor::execute(const Trace& trace, const ReplayConfig& config) {
+    if (config.dry_run) {
+        return true;
+    }
+
+    // Sleep for the duration of the operation instead of doing actual I/O
+    double duration_us = static_cast<double>(trace.time_end - trace.time_start);
+
+    // Cap individual operation sleeps to 1ms for practical testing
+    const double MAX_DFTRACER_SLEEP_US = 1.0 * 1000.0;
+    if (duration_us > MAX_DFTRACER_SLEEP_US) {
+        duration_us = MAX_DFTRACER_SLEEP_US;
+    }
+
+    if (config.no_sleep) {
+        if (config.verbose && duration_us >= 100000.0) {
+            std::cout << "DFTracer would sleep for " << std::fixed
+                      << std::setprecision(3) << duration_us / 1000.0
+                      << " ms for " << trace.func_name << " (skipped)"
+                      << std::endl;
+        }
+    } else {
+        if (config.verbose && duration_us >= 100.0) {
+            std::cout << "DFTracer sleeping for " << std::fixed
+                      << std::setprecision(3) << duration_us / 1000.0
+                      << " ms for " << trace.func_name << std::endl;
+        }
+        sleep_for_duration(duration_us);
+    }
+
+    return true;
+}
+
+bool DFTracerExecutor::can_handle([[maybe_unused]] const Trace& trace) const {
+    return true;  // Handle all trace events
+}
+
+void DFTracerExecutor::sleep_for_duration(double duration_microseconds) {
+    if (duration_microseconds <= 0) return;
+
+    const double MAX_SLEEP_US = 10.0 * 1000.0 * 1000.0;
+    if (duration_microseconds > MAX_SLEEP_US) {
+        duration_microseconds = MAX_SLEEP_US;
+    }
+
+    auto sleep_duration = std::chrono::nanoseconds(
+        static_cast<std::int64_t>(duration_microseconds * 1000));
+    std::this_thread::sleep_for(sleep_duration);
+}
+
+// =============================================================================
+// ReplayEngine Implementation
+// =============================================================================
+
+ReplayEngine::ReplayEngine(const ReplayConfig& config)
+    : config_(config), replay_start_time_(std::chrono::steady_clock::now()) {
+    if (config.dftracer_mode) {
+        add_executor(std::make_unique<DFTracerExecutor>());
+    } else {
+        add_executor(std::make_unique<PosixExecutor>());
+    }
+}
+
+ReplayEngine::ReplayEngine(const std::string& /* trace_file */,
+                           const ReplayConfig& config)
+    : config_(config), replay_start_time_(std::chrono::steady_clock::now()) {
+    if (config.dftracer_mode) {
+        add_executor(std::make_unique<DFTracerExecutor>());
+    } else {
+        add_executor(std::make_unique<PosixExecutor>());
+    }
+}
+
+ReplayEngine::~ReplayEngine() = default;
+
+void ReplayEngine::add_executor(std::unique_ptr<TraceExecutor> executor) {
+    executors_.push_back(std::move(executor));
+}
+
+ReplayResult ReplayEngine::replay(const std::string& trace_file,
+                                  const std::string& index_file) {
+    ReplayResult result;
+
+    DFTRACER_UTILS_LOG_DEBUG("Starting replay of file: %s", trace_file.c_str());
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    try {
+        // Check if the file is compressed
+        bool is_compressed =
+            (trace_file.size() >= 3 &&
+             trace_file.substr(trace_file.size() - 3) == ".gz") ||
+            (trace_file.size() >= 7 &&
+             trace_file.substr(trace_file.size() - 7) == ".tar.gz");
+
+        if (is_compressed) {
+            // Handle compressed files with ReaderFactory
+            std::string idx_path =
+                index_file.empty() ? utilities::composites::dft::internal::
+                                         determine_index_path(trace_file, "")
+                                   : index_file;
+
+            auto reader =
+                reader::internal::ReaderFactory::create(trace_file, idx_path);
+
+            if (!reader) {
+                result.error_messages.push_back(
+                    "Failed to create reader for file: " + trace_file);
+                return result;
+            }
+
+            // Create line processor for handling trace lines
+            ReplayLineProcessor processor(*this, result);
+
+            // Read all lines using the line processor
+            reader->read_lines_with_processor(0, reader->get_num_lines(),
+                                              processor);
+        } else {
+            // Handle plain text files directly
+            std::ifstream file(trace_file);
+            if (!file.is_open()) {
+                result.error_messages.push_back(
+                    "Failed to open plain text file: " + trace_file);
+                return result;
+            }
+
+            std::string line;
+            while (std::getline(file, line)) {
+                // Skip empty lines and bracket lines
+                if (line.empty() || line == "[" || line == "]") {
+                    continue;
+                }
+
+                // Remove trailing comma if present
+                if (!line.empty() && line.back() == ',') {
+                    line.pop_back();
+                }
+
+                process_trace_line(line, result);
+            }
+        }
+
+    } catch (const std::exception& e) {
+        result.error_messages.push_back("Exception during replay: " +
+                                        std::string(e.what()));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    result.total_duration =
+        std::chrono::duration_cast<std::chrono::microseconds>(end_time -
+                                                              start_time);
+
+    DFTRACER_UTILS_LOG_DEBUG(
+        "Replay completed. Total events: %zu, Executed: %zu, Failed: %zu",
+        result.total_events, result.executed_events, result.failed_events);
+
+    return result;
+}
+
+ReplayResult ReplayEngine::replay(const std::vector<std::string>& trace_files) {
+    ReplayResult aggregated_result;
+
+    for (const auto& file : trace_files) {
+        ReplayResult file_result = replay(file);
+
+        // Aggregate results
+        aggregated_result.total_events += file_result.total_events;
+        aggregated_result.executed_events += file_result.executed_events;
+        aggregated_result.filtered_events += file_result.filtered_events;
+        aggregated_result.failed_events += file_result.failed_events;
+        aggregated_result.total_duration += file_result.total_duration;
+        aggregated_result.execution_duration += file_result.execution_duration;
+
+        // Merge function and category counts
+        for (const auto& [func, count] : file_result.function_counts) {
+            aggregated_result.function_counts[func] += count;
+        }
+        for (const auto& [cat, count] : file_result.category_counts) {
+            aggregated_result.category_counts[cat] += count;
+        }
+
+        // Merge error messages
+        aggregated_result.error_messages.insert(
+            aggregated_result.error_messages.end(),
+            file_result.error_messages.begin(),
+            file_result.error_messages.end());
+    }
+
+    return aggregated_result;
+}
+
+bool ReplayEngine::process_trace_line(const std::string& line,
+                                      ReplayResult& result) {
+    Trace trace;
+
+    if (!parse_trace_json(line, trace)) {
+        return false;
+    }
+
+    result.total_events++;
+    result.function_counts[trace.func_name]++;
+    result.category_counts[trace.cat]++;
+    result.pid_counts[static_cast<std::uint32_t>(trace.pid)]++;
+    result.tid_counts[static_cast<std::uint32_t>(trace.tid)]++;
+
+    // Track timestamp range
+    if (trace.time_start > 0) {
+        if (trace.time_start < result.first_timestamp) {
+            result.first_timestamp = trace.time_start;
+        }
+        if (trace.time_start > result.last_timestamp) {
+            result.last_timestamp = trace.time_start;
+        }
+    }
+
+    // Track I/O bytes
+    if (trace.size > 0) {
+        if (trace.func_name.find("read") != std::string::npos ||
+            trace.func_name.find("Read") != std::string::npos) {
+            result.total_bytes_read += static_cast<std::size_t>(trace.size);
+        } else if (trace.func_name.find("write") != std::string::npos ||
+                   trace.func_name.find("Write") != std::string::npos) {
+            result.total_bytes_written += static_cast<std::size_t>(trace.size);
+        }
+    }
+
+    // Check max events limit
+    if (config_.max_events > 0 &&
+        result.executed_events >= config_.max_events) {
+        // Silently skip - limit already reached
+        return false;
+    }
+
+    if (!should_execute_trace(trace)) {
+        result.filtered_events++;
+        return true;
+    }
+
+    // Apply timing logic (skip during dry-run or dftracer-mode)
+    if (config_.maintain_timing && !config_.dry_run && !config_.dftracer_mode &&
+        trace.time_start > 0 && trace.type == TraceType::Regular) {
+        apply_timing(trace);
+    }
+
+    // Find and execute with appropriate executor
+    TraceExecutor* executor = find_executor(trace);
+    if (executor) {
+        auto exec_start = std::chrono::steady_clock::now();
+        bool success = executor->execute(trace, config_);
+        auto exec_end = std::chrono::steady_clock::now();
+
+        result.execution_duration +=
+            std::chrono::duration_cast<std::chrono::microseconds>(exec_end -
+                                                                  exec_start);
+
+        if (success) {
+            result.executed_events++;
+        } else {
+            result.failed_events++;
+            result.error_messages.push_back("Failed to execute " +
+                                            trace.func_name + " with " +
+                                            executor->get_name());
+        }
+    } else {
+        result.failed_events++;
+        if (config_.verbose) {
+            DFTRACER_UTILS_LOG_DEBUG(
+                "No executor found for function: %s (category: %s)",
+                trace.func_name.c_str(), trace.cat.c_str());
+        }
+    }
+
+    return true;
+}
+
+bool ReplayEngine::parse_trace_json(const std::string& json_line,
+                                    Trace& trace) {
+    const char* trimmed;
+    std::size_t trimmed_length;
+    if (!json_trim_and_validate(json_line.c_str(), json_line.length(), trimmed,
+                                trimmed_length)) {
+        return false;
+    }
+
+    yyjson_doc* doc = yyjson_read(trimmed, trimmed_length, 0);
+    if (!doc) {
+        return false;
+    }
+
+    yyjson_val* root = yyjson_doc_get_root(doc);
+    if (!root || !yyjson_is_obj(root)) {
+        yyjson_doc_free(doc);
+        return false;
+    }
+
+    // Parse basic fields
+    trace.func_name = get_json_string(root, "name");
+    trace.cat = get_json_string(root, "cat");
+    std::string phase = get_json_string(root, "ph");
+
+    trace.pid = get_json_uint64(root, "pid");
+    trace.tid = get_json_uint64(root, "tid");
+    trace.time_start = get_json_uint64(root, "ts");
+    trace.duration = get_json_double(root, "dur");
+    trace.time_end =
+        trace.time_start + static_cast<std::uint64_t>(trace.duration);
+
+    // Parse arguments
+    trace.fhash = get_args_string(root, "fhash");
+    trace.hhash = get_args_string(root, "hhash");
+    trace.size = get_args_int64(root, "size", -1);
+    trace.offset = get_args_int64(root, "offset", -1);
+
+    // Determine trace type
+    if (phase == "M") {
+        if (trace.func_name == "FH") {
+            trace.type = TraceType::FileHash;
+        } else if (trace.func_name == "HH") {
+            trace.type = TraceType::HostHash;
+        } else {
+            trace.type = TraceType::OtherMetadata;
+        }
+    } else {
+        trace.type = TraceType::Regular;
+    }
+
+    trace.is_valid = !trace.func_name.empty();
+
+    yyjson_doc_free(doc);
+    return trace.is_valid;
+}
+
+void ReplayEngine::apply_timing(const Trace& trace) {
+    if (!config_.maintain_timing) {
+        return;
+    }
+
+    if (!first_timestamp_set_) {
+        first_trace_timestamp_ = trace.time_start;
+        first_timestamp_set_ = true;
+        return;
+    }
+
+    // Calculate elapsed time since first trace
+    std::uint64_t trace_elapsed_us = trace.time_start - first_trace_timestamp_;
+
+    // Apply timing scale
+    std::uint64_t scaled_elapsed_us =
+        static_cast<std::uint64_t>(trace_elapsed_us * config_.timing_scale);
+
+    // Calculate how long we should sleep
+    auto replay_elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - replay_start_time_);
+
+    if (scaled_elapsed_us >
+        static_cast<std::uint64_t>(replay_elapsed.count())) {
+        std::uint64_t sleep_us =
+            scaled_elapsed_us -
+            static_cast<std::uint64_t>(replay_elapsed.count());
+
+        const std::uint64_t MAX_SLEEP_US = 10 * 1000 * 1000;
+        if (sleep_us > MAX_SLEEP_US) {
+            if (config_.verbose) {
+                std::cout << "Warning: Capping sleep from " << sleep_us / 1000.0
+                          << " ms to " << MAX_SLEEP_US / 1000.0 << " ms"
+                          << std::endl;
+            }
+            sleep_us = MAX_SLEEP_US;
+        }
+
+        if (config_.verbose && sleep_us > 1000) {
+            std::cout << "Timing sleep: " << sleep_us / 1000.0 << " ms"
+                      << std::endl;
+        }
+
+        std::this_thread::sleep_for(std::chrono::microseconds(sleep_us));
+    }
+}
+
+bool ReplayEngine::should_execute_trace(const Trace& trace) const {
+    // Check PID filters
+    if (!config_.filter_pids.empty()) {
+        if (config_.filter_pids.find(static_cast<std::uint32_t>(trace.pid)) ==
+            config_.filter_pids.end()) {
+            return false;
+        }
+    }
+    if (!config_.exclude_pids.empty()) {
+        if (config_.exclude_pids.find(static_cast<std::uint32_t>(trace.pid)) !=
+            config_.exclude_pids.end()) {
+            return false;
+        }
+    }
+
+    // Check TID filters
+    if (!config_.filter_tids.empty()) {
+        if (config_.filter_tids.find(static_cast<std::uint32_t>(trace.tid)) ==
+            config_.filter_tids.end()) {
+            return false;
+        }
+    }
+    if (!config_.exclude_tids.empty()) {
+        if (config_.exclude_tids.find(static_cast<std::uint32_t>(trace.tid)) !=
+            config_.exclude_tids.end()) {
+            return false;
+        }
+    }
+
+    // Check timestamp filters
+    if (config_.start_timestamp > 0 &&
+        trace.time_start < config_.start_timestamp) {
+        return false;
+    }
+    if (config_.end_timestamp < UINT64_MAX &&
+        trace.time_start > config_.end_timestamp) {
+        return false;
+    }
+
+    // Check operation size filters
+    if (config_.min_operation_size >= 0 && trace.size >= 0 &&
+        trace.size < config_.min_operation_size) {
+        return false;
+    }
+    if (config_.max_operation_size >= 0 && trace.size >= 0 &&
+        trace.size > config_.max_operation_size) {
+        return false;
+    }
+
+    // Check function filters
+    if (!config_.filter_functions.empty()) {
+        if (config_.filter_functions.find(trace.func_name) ==
+            config_.filter_functions.end()) {
+            return false;
+        }
+    }
+    if (!config_.exclude_functions.empty()) {
+        if (config_.exclude_functions.find(trace.func_name) !=
+            config_.exclude_functions.end()) {
+            return false;
+        }
+    }
+
+    // Check category filters
+    if (!config_.filter_categories.empty()) {
+        if (config_.filter_categories.find(trace.cat) ==
+            config_.filter_categories.end()) {
+            return false;
+        }
+    }
+    if (!config_.exclude_categories.empty()) {
+        if (config_.exclude_categories.find(trace.cat) !=
+            config_.exclude_categories.end()) {
+            return false;
+        }
+    }
+
+    // Apply sampling
+    if (config_.sampling_rate < 1.0) {
+        if (config_.sample_deterministic) {
+            std::hash<std::uint64_t> hasher;
+            std::size_t hash = hasher(trace.pid + trace.tid + trace.time_start +
+                                      config_.sample_seed);
+            double normalized = static_cast<double>(hash % 10000) / 10000.0;
+            if (normalized >= config_.sampling_rate) {
+                return false;
+            }
+        } else {
+            static std::mt19937_64 rng(config_.sample_seed);
+            static std::uniform_real_distribution<double> dist(0.0, 1.0);
+            if (dist(rng) >= config_.sampling_rate) {
+                return false;
+            }
+        }
+    }
+
+    // Skip metadata events by default
+    if (trace.type != TraceType::Regular) {
+        return false;
+    }
+
+    return true;
+}
+
+TraceExecutor* ReplayEngine::find_executor(const Trace& trace) {
+    for (auto& executor : executors_) {
+        if (executor->can_handle(trace)) {
+            return executor.get();
+        }
+    }
+    return nullptr;
+}
+
+std::string ReplayEngine::get_replay_file_path(
+    const std::string& original_path) const {
+    if (config_.output_directory.empty()) {
+        return original_path;
+    }
+
+    std::size_t last_slash = original_path.find_last_of('/');
+    std::string filename = (last_slash != std::string::npos)
+                               ? original_path.substr(last_slash + 1)
+                               : original_path;
+
+    return config_.output_directory + "/" + filename;
+}
+
+// =============================================================================
+// Call Tree Replay Implementation
+// =============================================================================
+
+ReplayResult ReplayEngine::replay_with_call_tree(
+    const std::string& trace_directory, const std::string& pattern) {
+    ReplayResult result;
+
+    DFTRACER_UTILS_LOG_DEBUG("Starting call tree replay from directory: %s",
+                             trace_directory.c_str());
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    try {
+        // Create CallTree instance using public API
+        dftracer::utils::call_tree::CallTree call_tree;
+
+        // Load trace files into call tree
+        DFTRACER_UTILS_LOG_DEBUG("Loading trace files into call tree...");
+        if (!call_tree.load_from_directory(trace_directory, pattern)) {
+            result.error_messages.push_back(
+                "Failed to load trace files from directory: " +
+                trace_directory);
+            return result;
+        }
+
+        // Generate the call tree structure
+        DFTRACER_UTILS_LOG_DEBUG("Generating call tree structure...");
+        if (!call_tree.generate()) {
+            result.error_messages.push_back(
+                "Failed to generate call tree structure");
+            return result;
+        }
+
+        // Get statistics before replay
+        auto stats = call_tree.get_statistics();
+        result.total_nodes = stats.total_nodes;
+        result.tree_depth = static_cast<std::size_t>(stats.max_depth);
+        result.unique_processes = stats.unique_processes;
+
+        DFTRACER_UTILS_LOG_DEBUG(
+            "Call tree loaded: %zu nodes, depth %d, %zu processes",
+            result.total_nodes, stats.max_depth, result.unique_processes);
+
+        // Replay from the call tree
+        if (config_.hierarchical_replay) {
+            DFTRACER_UTILS_LOG_DEBUG("Performing hierarchical replay...");
+            replay_from_call_tree(call_tree, result);
+        } else {
+            DFTRACER_UTILS_LOG_DEBUG(
+                "Performing linear replay with call tree filtering...");
+            auto nodes = call_tree.get_all_nodes();
+            for (const auto& node : nodes) {
+                replay_call_tree_node(node, result);
+            }
+        }
+
+    } catch (const std::exception& e) {
+        result.error_messages.push_back("Exception during call tree replay: " +
+                                        std::string(e.what()));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    result.total_duration =
+        std::chrono::duration_cast<std::chrono::microseconds>(end_time -
+                                                              start_time);
+
+    DFTRACER_UTILS_LOG_DEBUG(
+        "Call tree replay completed. Total nodes: %zu, Executed: %zu, Failed: "
+        "%zu",
+        result.total_nodes, result.executed_events, result.failed_events);
+
+    return result;
+}
+
+void ReplayEngine::replay_from_call_tree(
+    dftracer::utils::call_tree::CallTree& call_tree, ReplayResult& result) {
+    // Get root nodes for each process
+    auto processes = call_tree.get_process_ids();
+
+    for (std::uint32_t pid : processes) {
+        auto threads = call_tree.get_thread_ids(pid);
+
+        for (std::uint32_t tid : threads) {
+            auto root_nodes = call_tree.get_root_nodes(pid, tid);
+
+            DFTRACER_UTILS_LOG_DEBUG(
+                "Processing process %u, thread %u: %zu root nodes", pid, tid,
+                root_nodes.size());
+
+            for (const auto& root_node : root_nodes) {
+                replay_call_tree_node_recursive(root_node, call_tree, result,
+                                                0);
+            }
+        }
+    }
+}
+
+void ReplayEngine::replay_call_tree_node_recursive(
+    const dftracer::utils::call_tree::CallTreeNodeInfo& node,
+    dftracer::utils::call_tree::CallTree& call_tree, ReplayResult& result,
+    int depth) {
+    // Apply depth limits if configured
+    if (config_.max_level >= 0 && depth > config_.max_level) {
+        result.filtered_events++;
+        return;
+    }
+    if (config_.min_level >= 0 && depth < config_.min_level) {
+        result.filtered_events++;
+        return;
+    }
+
+    // Replay the current node
+    replay_call_tree_node(node, result);
+
+    // If respecting call hierarchy, replay children
+    if (config_.respect_call_hierarchy) {
+        for (std::uint64_t child_id : node.children_ids) {
+            auto child_node = call_tree.get_node_by_id(child_id);
+            if (child_node.id != 0) {
+                replay_call_tree_node_recursive(child_node, call_tree, result,
+                                                depth + 1);
+            }
+        }
+    }
+}
+
+void ReplayEngine::replay_call_tree_node(
+    const dftracer::utils::call_tree::CallTreeNodeInfo& node,
+    ReplayResult& result) {
+    // Convert CallTreeNodeInfo to Trace structure
+    Trace trace;
+    trace.func_name = node.name;
+    trace.cat = node.category;
+    trace.time_start = node.start_time_us;
+    trace.duration = static_cast<double>(node.duration_us);
+    trace.time_end = trace.time_start + node.duration_us;
+    trace.type = TraceType::Regular;
+    trace.is_valid = true;
+
+    // Extract args from node
+    const auto& args = node.args;
+
+    auto pid_it = args.find("pid");
+    if (pid_it != args.end()) {
+        try {
+            trace.pid = std::stoull(pid_it->second);
+        } catch (...) {
+            trace.pid = 0;
+        }
+    }
+
+    auto tid_it = args.find("tid");
+    if (tid_it != args.end()) {
+        try {
+            trace.tid = std::stoull(tid_it->second);
+        } catch (...) {
+            trace.tid = 0;
+        }
+    }
+
+    auto fhash_it = args.find("fhash");
+    if (fhash_it != args.end()) {
+        trace.fhash = fhash_it->second;
+    }
+
+    auto hhash_it = args.find("hhash");
+    if (hhash_it != args.end()) {
+        trace.hhash = hhash_it->second;
+    }
+
+    auto size_it = args.find("size");
+    if (size_it != args.end()) {
+        try {
+            trace.size = std::stoll(size_it->second);
+        } catch (...) {
+            trace.size = -1;
+        }
+    }
+
+    auto offset_it = args.find("offset");
+    if (offset_it != args.end()) {
+        try {
+            trace.offset = std::stoll(offset_it->second);
+        } catch (...) {
+            trace.offset = -1;
+        }
+    }
+
+    // Update result statistics
+    result.total_events++;
+    result.function_counts[trace.func_name]++;
+    result.category_counts[trace.cat]++;
+    result.pid_counts[static_cast<std::uint32_t>(trace.pid)]++;
+    result.tid_counts[static_cast<std::uint32_t>(trace.tid)]++;
+
+    // Track timestamp range
+    if (trace.time_start > 0) {
+        if (trace.time_start < result.first_timestamp) {
+            result.first_timestamp = trace.time_start;
+        }
+        if (trace.time_start > result.last_timestamp) {
+            result.last_timestamp = trace.time_start;
+        }
+    }
+
+    // Track I/O bytes
+    if (trace.size > 0) {
+        if (trace.func_name.find("read") != std::string::npos ||
+            trace.func_name.find("Read") != std::string::npos) {
+            result.total_bytes_read += static_cast<std::size_t>(trace.size);
+        } else if (trace.func_name.find("write") != std::string::npos ||
+                   trace.func_name.find("Write") != std::string::npos) {
+            result.total_bytes_written += static_cast<std::size_t>(trace.size);
+        }
+    }
+
+    // Check max events limit
+    if (config_.max_events > 0 &&
+        result.executed_events >= config_.max_events) {
+        // Silently skip - limit already reached
+        return;
+    }
+
+    // Apply filters
+    if (!should_execute_trace(trace)) {
+        result.filtered_events++;
+        return;
+    }
+
+    // Apply timing logic
+    if (config_.maintain_timing && !config_.dry_run && !config_.dftracer_mode &&
+        trace.time_start > 0) {
+        apply_timing(trace);
+    }
+
+    // Find and execute with appropriate executor
+    TraceExecutor* executor = find_executor(trace);
+    if (executor) {
+        auto exec_start = std::chrono::steady_clock::now();
+        bool success = executor->execute(trace, config_);
+        auto exec_end = std::chrono::steady_clock::now();
+
+        result.execution_duration +=
+            std::chrono::duration_cast<std::chrono::microseconds>(exec_end -
+                                                                  exec_start);
+
+        if (success) {
+            result.executed_events++;
+        } else {
+            result.failed_events++;
+            result.error_messages.push_back("Failed to execute " +
+                                            trace.func_name + " with " +
+                                            executor->get_name());
+        }
+    } else {
+        result.failed_events++;
+        if (config_.verbose) {
+            DFTRACER_UTILS_LOG_DEBUG(
+                "No executor found for function: %s (category: %s)",
+                trace.func_name.c_str(), trace.cat.c_str());
+        }
+    }
+}
+
+// =============================================================================
+// ReplayLineProcessor Implementation
+// =============================================================================
+
+ReplayLineProcessor::ReplayLineProcessor(ReplayEngine& engine,
+                                         ReplayResult& result)
+    : engine_(engine), result_(result) {}
+
+bool ReplayLineProcessor::process(const char* data, std::size_t length) {
+    std::string line(data, length);
+    return engine_.process_trace_line(line, result_);
+}
+
+// =============================================================================
+// ReplayResult::print_summary Implementation
+// =============================================================================
+
+void ReplayResult::print_summary(bool verbose) const {
+    std::cout << "\n=== Replay Summary ===" << std::endl;
+    std::cout << "Total events: " << total_events << std::endl;
+    std::cout << "Executed: " << executed_events << std::endl;
+    std::cout << "Filtered: " << filtered_events << std::endl;
+    std::cout << "Failed: " << failed_events << std::endl;
+
+    double success_rate = total_events > 0
+                              ? (static_cast<double>(executed_events) /
+                                 static_cast<double>(total_events) * 100.0)
+                              : 0.0;
+    std::cout << "Success rate: " << std::fixed << std::setprecision(2)
+              << success_rate << "%" << std::endl;
+
+    std::cout << "\nTiming:" << std::endl;
+    std::cout << "  Total duration: " << total_duration.count() / 1000.0
+              << " ms" << std::endl;
+    std::cout << "  Execution duration: " << execution_duration.count() / 1000.0
+              << " ms" << std::endl;
+
+    if (first_timestamp != UINT64_MAX && last_timestamp > 0) {
+        std::cout << "  Trace timespan: "
+                  << static_cast<double>(last_timestamp - first_timestamp) /
+                         1000000.0
+                  << " seconds" << std::endl;
+    }
+
+    std::cout << "\nI/O Statistics:" << std::endl;
+    std::cout << "  Bytes read: " << total_bytes_read << " ("
+              << static_cast<double>(total_bytes_read) / (1024.0 * 1024.0)
+              << " MB)" << std::endl;
+    std::cout << "  Bytes written: " << total_bytes_written << " ("
+              << static_cast<double>(total_bytes_written) / (1024.0 * 1024.0)
+              << " MB)" << std::endl;
+
+    std::cout << "\nProcess/Thread Statistics:" << std::endl;
+    std::cout << "  Unique PIDs: " << pid_counts.size() << std::endl;
+    std::cout << "  Unique TIDs: " << tid_counts.size() << std::endl;
+
+    if (verbose) {
+        if (!pid_counts.empty()) {
+            std::cout << "\n  Events per PID:" << std::endl;
+            for (const auto& [pid, count] : pid_counts) {
+                std::cout << "    PID " << pid << ": " << count << " events"
+                          << std::endl;
+            }
+        }
+
+        if (!tid_counts.empty() && tid_counts.size() > 1) {
+            std::cout << "\n  Events per TID:" << std::endl;
+            for (const auto& [tid, count] : tid_counts) {
+                std::cout << "    TID " << tid << ": " << count << " events"
+                          << std::endl;
+            }
+        }
+
+        if (!function_counts.empty()) {
+            std::cout << "\n  Top functions by count:" << std::endl;
+            std::vector<std::pair<std::string, std::size_t>> sorted_funcs(
+                function_counts.begin(), function_counts.end());
+            std::sort(sorted_funcs.begin(), sorted_funcs.end(),
+                      [](const auto& a, const auto& b) {
+                          return a.second > b.second;
+                      });
+
+            std::size_t max_display =
+                std::min(sorted_funcs.size(), std::size_t(10));
+            for (std::size_t i = 0; i < max_display; i++) {
+                std::cout << "    " << std::setw(30) << std::left
+                          << sorted_funcs[i].first << ": "
+                          << sorted_funcs[i].second << std::endl;
+            }
+        }
+
+        if (!category_counts.empty()) {
+            std::cout << "\n  Events per category:" << std::endl;
+            for (const auto& [cat, count] : category_counts) {
+                std::cout << "    " << std::setw(20) << std::left << cat << ": "
+                          << count << std::endl;
+            }
+        }
+    }
+
+    if (!error_messages.empty()) {
+        std::cout << "\n=== Errors (" << error_messages.size()
+                  << " total) ===" << std::endl;
+        std::size_t max_errors =
+            std::min(error_messages.size(), std::size_t(10));
+        for (std::size_t i = 0; i < max_errors; i++) {
+            std::cout << "  " << error_messages[i] << std::endl;
+        }
+        if (error_messages.size() > 10) {
+            std::cout << "  ... and " << (error_messages.size() - 10)
+                      << " more errors" << std::endl;
+        }
+    }
+
+    std::cout << "=====================" << std::endl;
+}
+
+}  // namespace dftracer::utils::utilities::replay

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,9 @@ set(TEST_CPP_SOURCES
     reader/test_reader_formats.cpp
     reader/test_reader_robustness.cpp
     # reader/test_reader_tar_comprehensive.cpp
+    # Replay tests
+    test_replay.cpp
+    test_replay_binary.cpp
     )
 
 foreach(test_file ${TEST_CPP_SOURCES})
@@ -61,6 +64,9 @@ foreach(test_file ${TEST_CPP_SOURCES})
   target_link_libraries(${target_name} PRIVATE doctest::doctest testing_utilities)
   target_set_warnings(${target_name})
   target_enable_coroutine(${target_name})
+  
+  # Pass CMAKE_BINARY_DIR to tests that need to execute binaries
+  target_compile_definitions(${target_name} PRIVATE CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR}")
 
   # Set output directory to preserve folder structure in binaries
   get_filename_component(bin_dir ${bin_exec} DIRECTORY)
@@ -81,6 +87,13 @@ foreach(test_file ${TEST_CPP_SOURCES})
   endif()
 
   add_test(NAME ${bin_exec} COMMAND ${target_name})
+
+  # Ensure binary tests can find the dftracer_replay executable
+  if("${target_name}" STREQUAL "test_replay_binary")
+    if(TARGET dftracer_replay)
+      add_dependencies(${target_name} dftracer_replay)
+    endif()
+  endif()
 endforeach()
 
 # +++++++++++++++++++++++++++++++++++++++++

--- a/tests/coro/test_coro_syntax.cpp
+++ b/tests/coro/test_coro_syntax.cpp
@@ -42,7 +42,7 @@ TEST_CASE("CoroTask - then() with transformation inside coroutine") {
             // Use then() to transform the result
             auto transformed = compute().then([](int x) { return x * 2; });
 
-            int result = co_await transformed;
+            int result = co_await std::move(transformed);
             co_return std::to_string(result);
         },
         "Parent");

--- a/tests/pipeline/test_io_pipeline.cpp
+++ b/tests/pipeline/test_io_pipeline.cpp
@@ -18,6 +18,29 @@
 
 using namespace dftracer::utils;
 
+namespace {
+
+fs::path make_test_io_directory(const std::string& name) {
+    static std::atomic<std::uint64_t> counter{0};
+
+    const auto unique_suffix =
+        std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count()) +
+        "_" + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+
+    const auto test_dir =
+        fs::temp_directory_path() / (name + "_" + unique_suffix);
+    fs::create_directories(test_dir);
+    return test_dir;
+}
+
+void cleanup_test_io_directory(const fs::path& test_dir) {
+    std::error_code ec;
+    fs::remove_all(test_dir, ec);
+}
+
+}  // namespace
+
 // ============================================================================
 // IOExecutor Basic Tests
 // ============================================================================
@@ -639,9 +662,9 @@ TEST_CASE("Real IO - Write and read file") {
 
     io_executor->start();
 
+    const auto test_dir = make_test_io_directory("test_io_executor_write_read");
     const auto test_file =
-        (fs::temp_directory_path() / "test_io_executor_write_read.txt")
-            .string();
+        (test_dir / "test_io_executor_write_read.txt").string();
     const std::string test_data = "Hello from IOExecutor!";
     std::atomic<bool> write_done{false};
     std::atomic<bool> read_done{false};
@@ -693,7 +716,7 @@ TEST_CASE("Real IO - Write and read file") {
     CHECK(read_data == test_data);
 
     // Cleanup
-    std::remove(test_file.c_str());
+    cleanup_test_io_directory(test_dir);
 
     io_executor->shutdown();
 }
@@ -705,14 +728,14 @@ TEST_CASE("Real IO - Multiple file writes") {
     io_executor->start();
 
     constexpr int NUM_FILES = 10;
+    const auto test_dir = make_test_io_directory("test_io_executor_files");
     std::atomic<int> completed{0};
     std::vector<std::string> file_paths;
 
     // Create multiple write operations
     for (int i = 0; i < NUM_FILES; ++i) {
         auto file_path =
-            (fs::temp_directory_path() /
-             ("test_io_executor_file_" + std::to_string(i) + ".txt"))
+            (test_dir / ("test_io_executor_file_" + std::to_string(i) + ".txt"))
                 .string();
         file_paths.push_back(file_path);
 
@@ -750,9 +773,7 @@ TEST_CASE("Real IO - Multiple file writes") {
     }
 
     // Cleanup
-    for (const auto& path : file_paths) {
-        std::remove(path.c_str());
-    }
+    cleanup_test_io_directory(test_dir);
 
     io_executor->shutdown();
 }
@@ -764,24 +785,27 @@ TEST_CASE("Real IO - Concurrent reads and writes") {
     io_executor->start();
 
     constexpr int NUM_OPS = 20;
+    const auto test_dir = make_test_io_directory("test_io_concurrent");
     std::atomic<int> write_count{0};
     std::atomic<int> read_count{0};
     std::vector<std::string> file_paths;
 
     // Submit interleaved write and read operations
     for (int i = 0; i < NUM_OPS / 2; ++i) {
-        auto file_path = (fs::temp_directory_path() /
-                          ("test_io_concurrent_" + std::to_string(i) + ".txt"))
-                             .string();
+        auto file_path =
+            (test_dir / ("test_io_concurrent_" + std::to_string(i) + ".txt"))
+                .string();
         file_paths.push_back(file_path);
+        auto write_ready = std::make_shared<std::atomic<bool>>(false);
 
         // Write operation
-        auto write_func = [file_path, i, &write_count]() {
+        auto write_func = [file_path, i, write_ready, &write_count]() {
             FILE* f = fopen(file_path.c_str(), "w");
             if (f) {
                 std::string content = "Data " + std::to_string(i * 100);
                 fwrite(content.c_str(), 1, content.size(), f);
                 fclose(f);
+                write_ready->store(true, std::memory_order_release);
                 write_count.fetch_add(1);
             }
         };
@@ -789,17 +813,28 @@ TEST_CASE("Real IO - Concurrent reads and writes") {
         io_executor->submit_io_operation(write_func, std::coroutine_handle<>{},
                                          i % 8);
 
-        // Short delay to ensure write happens first
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
         // Read operation
-        auto read_func = [file_path, &read_count]() {
-            FILE* f = fopen(file_path.c_str(), "r");
-            if (f) {
-                char buffer[256];
-                fread(buffer, 1, sizeof(buffer), f);
-                fclose(f);
-                read_count.fetch_add(1);
+        auto read_func = [file_path, write_ready, &read_count]() {
+            auto deadline =
+                std::chrono::steady_clock::now() + std::chrono::seconds(5);
+
+            while (std::chrono::steady_clock::now() < deadline) {
+                if (!write_ready->load(std::memory_order_acquire)) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                    continue;
+                }
+
+                FILE* f = fopen(file_path.c_str(), "r");
+                if (f) {
+                    char buffer[256];
+                    [[maybe_unused]] size_t bytes_read =
+                        fread(buffer, 1, sizeof(buffer), f);
+                    fclose(f);
+                    read_count.fetch_add(1);
+                    return;
+                }
+
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
             }
         };
 
@@ -810,7 +845,8 @@ TEST_CASE("Real IO - Concurrent reads and writes") {
     // Wait for all operations to complete
     auto start = std::chrono::steady_clock::now();
     while ((write_count.load() + read_count.load()) < NUM_OPS &&
-           std::chrono::steady_clock::now() - start < std::chrono::seconds(5)) {
+           std::chrono::steady_clock::now() - start <
+               std::chrono::seconds(10)) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
@@ -818,9 +854,7 @@ TEST_CASE("Real IO - Concurrent reads and writes") {
     CHECK(read_count.load() == NUM_OPS / 2);
 
     // Cleanup
-    for (const auto& path : file_paths) {
-        std::remove(path.c_str());
-    }
+    cleanup_test_io_directory(test_dir);
 
     io_executor->shutdown();
 }
@@ -831,8 +865,8 @@ TEST_CASE("Real IO - Large file write and read") {
 
     io_executor->start();
 
-    const auto test_file =
-        (fs::temp_directory_path() / "test_io_large_file.bin").string();
+    const auto test_dir = make_test_io_directory("test_io_large_file");
+    const auto test_file = (test_dir / "test_io_large_file.bin").string();
     constexpr size_t FILE_SIZE = 1024 * 1024;  // 1 MB
     std::vector<char> write_data(FILE_SIZE);
 
@@ -892,7 +926,7 @@ TEST_CASE("Real IO - Large file write and read") {
     CHECK(read_data == write_data);
 
     // Cleanup
-    std::remove(test_file.c_str());
+    cleanup_test_io_directory(test_dir);
 
     io_executor->shutdown();
 }
@@ -903,8 +937,8 @@ TEST_CASE("Real IO - File stat operations") {
 
     io_executor->start();
 
-    const auto test_file =
-        (fs::temp_directory_path() / "test_io_stat.txt").string();
+    const auto test_dir = make_test_io_directory("test_io_stat");
+    const auto test_file = (test_dir / "test_io_stat.txt").string();
     const std::string test_content = "Test content for stat";
 
     std::atomic<bool> write_done{false};
@@ -957,7 +991,7 @@ TEST_CASE("Real IO - File stat operations") {
     CHECK(file_size.load() == test_content.size());
 
     // Cleanup
-    std::remove(test_file.c_str());
+    cleanup_test_io_directory(test_dir);
 
     io_executor->shutdown();
 }

--- a/tests/test_replay.cpp
+++ b/tests/test_replay.cpp
@@ -1,0 +1,385 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <dftracer/utils/core/common/logging.h>
+#include <dftracer/utils/utilities/replay/replay.h>
+#include <doctest/doctest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "testing_utilities.h"
+
+using namespace dftracer::utils::utilities::replay;
+namespace fs = std::filesystem;
+
+TEST_CASE("DFTracer Replay - Basic functionality") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    // Create a temporary trace file with sample data
+    fs::path temp_dir = fs::temp_directory_path() / "dftracer_replay_test";
+    fs::create_directories(temp_dir);
+
+    std::string trace_file = (temp_dir / "test_trace.pfw").string();
+
+    SUBCASE("Create sample trace file") {
+        std::ofstream file(trace_file);
+        REQUIRE(file.is_open());
+
+        // Write sample trace entries based on the DFTracer format
+        file << "[\n";
+        file
+            << R"({"id":1,"name":"opendir","cat":"POSIX","pid":12345,"tid":12345,"ts":1000000,"dur":1500,"ph":"X","args":{"fhash":"abc123","level":1}})"
+            << "\n";
+        file
+            << R"({"id":2,"name":"read","cat":"POSIX","pid":12345,"tid":12345,"ts":1002000,"dur":2500,"ph":"X","args":{"fhash":"def456","size":1024,"level":1}})"
+            << "\n";
+        file
+            << R"({"id":3,"name":"write","cat":"POSIX","pid":12345,"tid":12345,"ts":1005000,"dur":3000,"ph":"X","args":{"fhash":"ghi789","size":2048,"level":1}})"
+            << "\n";
+        file
+            << R"({"id":4,"name":"fopen","cat":"STDIO","pid":12345,"tid":12345,"ts":1009000,"dur":500,"ph":"X","args":{"fhash":"jkl012","level":1}})"
+            << "\n";
+        file << "]";
+        file.close();
+
+        REQUIRE(fs::exists(trace_file));
+    }
+
+    SUBCASE("Test DFTracer sleep-based replay mode") {
+        // First create the trace file
+        {
+            std::ofstream file(trace_file);
+            file << "[\n";
+            file
+                << R"({"id":1,"name":"read","cat":"POSIX","pid":12345,"tid":12345,"ts":1000000,"dur":1500,"ph":"X","args":{"fhash":"abc123","size":1024}})"
+                << "\n";
+            file
+                << R"({"id":2,"name":"write","cat":"POSIX","pid":12345,"tid":12345,"ts":1002000,"dur":2500,"ph":"X","args":{"fhash":"def456","size":2048}})"
+                << "\n";
+            file << "]";
+            file.close();
+        }
+
+        ReplayConfig config;
+        config.dftracer_mode = true;
+        config.maintain_timing = false;
+        config.verbose = false;
+
+        ReplayEngine engine(config);
+
+        auto start_time = std::chrono::steady_clock::now();
+        ReplayResult result = engine.replay(trace_file);
+        auto end_time = std::chrono::steady_clock::now();
+
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+            end_time - start_time);
+
+        CHECK(result.total_events > 0);
+        CHECK(result.executed_events > 0);
+        CHECK(result.failed_events == 0);
+        CHECK(result.executed_events == result.total_events);
+
+        std::cout << "Processed " << result.total_events << " events in "
+                  << duration.count() << " microseconds" << std::endl;
+    }
+
+    SUBCASE("Test dry run mode") {
+        // First create the trace file
+        {
+            std::ofstream file(trace_file);
+            file << "[\n";
+            file
+                << R"({"id":1,"name":"read","cat":"POSIX","pid":12345,"tid":12345,"ts":1000000,"dur":1500,"ph":"X","args":{"fhash":"abc123","size":1024}})"
+                << "\n";
+            file << "]";
+            file.close();
+        }
+
+        ReplayConfig config;
+        config.dftracer_mode = false;
+        config.dry_run = true;
+        config.maintain_timing = false;
+
+        ReplayEngine engine(config);
+        ReplayResult result = engine.replay(trace_file);
+
+        CHECK(result.total_events > 0);
+        CHECK(result.executed_events > 0);
+        CHECK(result.failed_events == 0);
+
+        std::cout << "Dry run: " << result.executed_events << "/"
+                  << result.total_events << " executed" << std::endl;
+    }
+
+    SUBCASE("Test filter by category") {
+        // First create the trace file with multiple categories
+        {
+            std::ofstream file(trace_file);
+            file << "[\n";
+            file
+                << R"({"id":1,"name":"read","cat":"POSIX","pid":12345,"tid":12345,"ts":1000000,"dur":1500,"ph":"X","args":{}})"
+                << "\n";
+            file
+                << R"({"id":2,"name":"fopen","cat":"STDIO","pid":12345,"tid":12345,"ts":1002000,"dur":500,"ph":"X","args":{}})"
+                << "\n";
+            file
+                << R"({"id":3,"name":"write","cat":"POSIX","pid":12345,"tid":12345,"ts":1003000,"dur":2000,"ph":"X","args":{}})"
+                << "\n";
+            file << "]";
+            file.close();
+        }
+
+        ReplayConfig config;
+        config.dftracer_mode = true;
+        config.maintain_timing = false;
+        config.filter_categories.insert("POSIX");
+
+        ReplayEngine engine(config);
+        ReplayResult result = engine.replay(trace_file);
+
+        CHECK(result.total_events == 3);
+        CHECK(result.executed_events == 2);  // Only POSIX events
+        CHECK(result.filtered_events == 1);  // STDIO event filtered
+
+        std::cout << "Category filter: " << result.executed_events << "/"
+                  << result.total_events << " executed, "
+                  << result.filtered_events << " filtered" << std::endl;
+    }
+
+    SUBCASE("Test filter by function") {
+        // First create the trace file
+        {
+            std::ofstream file(trace_file);
+            file << "[\n";
+            file
+                << R"({"id":1,"name":"read","cat":"POSIX","pid":12345,"tid":12345,"ts":1000000,"dur":1500,"ph":"X","args":{}})"
+                << "\n";
+            file
+                << R"({"id":2,"name":"write","cat":"POSIX","pid":12345,"tid":12345,"ts":1002000,"dur":2500,"ph":"X","args":{}})"
+                << "\n";
+            file
+                << R"({"id":3,"name":"open","cat":"POSIX","pid":12345,"tid":12345,"ts":1005000,"dur":500,"ph":"X","args":{}})"
+                << "\n";
+            file << "]";
+            file.close();
+        }
+
+        ReplayConfig config;
+        config.dftracer_mode = true;
+        config.maintain_timing = false;
+        config.filter_functions.insert("read");
+        config.filter_functions.insert("write");
+
+        ReplayEngine engine(config);
+        ReplayResult result = engine.replay(trace_file);
+
+        CHECK(result.total_events == 3);
+        CHECK(result.executed_events == 2);  // Only read and write
+        CHECK(result.filtered_events == 1);  // open filtered
+
+        std::cout << "Function filter: " << result.executed_events << "/"
+                  << result.total_events << " executed" << std::endl;
+    }
+
+    SUBCASE("Test max events limit") {
+        // First create the trace file with many events
+        {
+            std::ofstream file(trace_file);
+            file << "[\n";
+            for (int i = 0; i < 10; i++) {
+                file
+                    << R"({"id":)" << i
+                    << R"(,"name":"read","cat":"POSIX","pid":12345,"tid":12345,"ts":)"
+                    << (1000000 + i * 1000)
+                    << R"(,"dur":100,"ph":"X","args":{}})";
+                if (i < 9) file << ",";
+                file << "\n";
+            }
+            file << "]";
+            file.close();
+        }
+
+        ReplayConfig config;
+        config.dftracer_mode = true;
+        config.maintain_timing = false;
+        config.max_events = 5;
+
+        ReplayEngine engine(config);
+        ReplayResult result = engine.replay(trace_file);
+
+        CHECK(result.executed_events <= 5);
+
+        std::cout << "Max events limit: " << result.executed_events << "/"
+                  << result.total_events << " executed (limit: 5)" << std::endl;
+    }
+
+    SUBCASE("Test sampling") {
+        // First create the trace file with many events
+        {
+            std::ofstream file(trace_file);
+            file << "[\n";
+            for (int i = 0; i < 100; i++) {
+                file
+                    << R"({"id":)" << i
+                    << R"(,"name":"read","cat":"POSIX","pid":12345,"tid":12345,"ts":)"
+                    << (1000000 + i * 1000)
+                    << R"(,"dur":100,"ph":"X","args":{}})";
+                if (i < 99) file << ",";
+                file << "\n";
+            }
+            file << "]";
+            file.close();
+        }
+
+        ReplayConfig config;
+        config.dftracer_mode = true;
+        config.maintain_timing = false;
+        config.sampling_rate = 0.5;  // 50% sampling
+        config.sample_deterministic = true;
+
+        ReplayEngine engine(config);
+        ReplayResult result = engine.replay(trace_file);
+
+        // With 50% sampling, we expect roughly half the events
+        // Allow some variance
+        CHECK(result.executed_events > 30);
+        CHECK(result.executed_events < 70);
+
+        std::cout << "Sampling (50%): " << result.executed_events << "/"
+                  << result.total_events << " executed" << std::endl;
+    }
+
+    // Cleanup
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST_CASE("DFTracer Replay - Trace structure") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    SUBCASE("Test Trace struct defaults") {
+        Trace trace;
+
+        CHECK(trace.pid == 0);
+        CHECK(trace.tid == 0);
+        CHECK(trace.time_start == 0);
+        CHECK(trace.duration == 0.0);
+        CHECK(trace.size == -1);
+        CHECK(trace.offset == -1);
+        CHECK(trace.is_valid == false);
+        CHECK(trace.type == TraceType::Regular);
+        CHECK(trace.is_metadata() == false);
+    }
+
+    SUBCASE("Test Trace helpers") {
+        Trace trace;
+        trace.time_start = 1000000;
+        trace.duration = 500.0;
+        trace.time_end = 1000500;
+        trace.size = 1024;
+
+        CHECK(trace.has_size() == true);
+        CHECK(trace.has_offset() == false);
+        CHECK(trace.has_valid_timing() == true);
+        CHECK(trace.get_end_time() == 1000500);
+    }
+}
+
+TEST_CASE("DFTracer Replay - ReplayResult statistics") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    SUBCASE("Test result aggregation") {
+        ReplayResult result;
+        result.total_events = 100;
+        result.executed_events = 80;
+        result.filtered_events = 15;
+        result.failed_events = 5;
+        result.function_counts["read"] = 50;
+        result.function_counts["write"] = 30;
+        result.category_counts["POSIX"] = 80;
+        result.total_bytes_read = 1024 * 1024;
+        result.total_bytes_written = 512 * 1024;
+
+        // Test print_summary doesn't crash
+        result.print_summary(false);
+        result.print_summary(true);
+    }
+}
+
+TEST_CASE("DFTracer Replay - Real trace files") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    // Test with real traces from trace_short directory
+    std::string trace_dir = "trace_short/bert_v100-1.pfw";
+
+    SUBCASE("Test with bert trace file") {
+        if (!fs::exists(trace_dir)) {
+            MESSAGE("Skipping real trace test - file not found: ", trace_dir);
+            return;
+        }
+
+        ReplayConfig config;
+        config.dftracer_mode = true;
+        config.no_sleep = true;  // Fast mode for testing
+        config.maintain_timing = false;
+        config.verbose = false;
+
+        ReplayEngine engine(config);
+
+        auto start_time = std::chrono::steady_clock::now();
+        ReplayResult result = engine.replay(trace_dir);
+        auto end_time = std::chrono::steady_clock::now();
+
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            end_time - start_time);
+
+        CHECK(result.total_events > 0);
+
+        std::cout << "Processed " << result.total_events
+                  << " events from bert trace in " << duration.count() << " ms"
+                  << std::endl;
+        std::cout << "Executed: " << result.executed_events
+                  << ", Failed: " << result.failed_events << std::endl;
+    }
+}
+
+TEST_CASE("DFTracer Replay - Call tree integration") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    // Test with trace_short/cosmoflow_h100/nodes-1 directory
+    std::string trace_dir = "trace_short/cosmoflow_h100/nodes-1";
+
+    SUBCASE("Test call tree replay") {
+        if (!fs::is_directory(trace_dir)) {
+            MESSAGE("Skipping call tree test - directory not found: ",
+                    trace_dir);
+            return;
+        }
+
+        ReplayConfig config;
+        config.dftracer_mode = true;
+        config.no_sleep = true;
+        config.maintain_timing = false;
+        config.verbose = false;
+        config.use_call_tree = true;
+        config.hierarchical_replay = false;
+
+        ReplayEngine engine(config);
+
+        auto start_time = std::chrono::steady_clock::now();
+        ReplayResult result = engine.replay_with_call_tree(trace_dir);
+        auto end_time = std::chrono::steady_clock::now();
+
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            end_time - start_time);
+
+        CHECK(result.total_events > 0);
+        CHECK(result.total_nodes > 0);
+
+        std::cout << "Call tree replay: " << result.total_nodes << " nodes, "
+                  << result.executed_events << " executed in "
+                  << duration.count() << " ms" << std::endl;
+    }
+}

--- a/tests/test_replay_binary.cpp
+++ b/tests/test_replay_binary.cpp
@@ -1,0 +1,519 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <dftracer/utils/core/common/logging.h>
+#include <doctest/doctest.h>
+#include <sys/wait.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "testing_utilities.h"
+
+namespace fs = std::filesystem;
+
+// Helper to execute the dftracer_replay binary
+struct BinaryResult {
+    int exit_code;
+    std::string stdout_output;
+    std::string stderr_output;
+};
+
+BinaryResult execute_replay_binary(const std::string& args) {
+    std::string binary_path = CMAKE_BINARY_DIR "/bin/dftracer_replay";
+
+    // Verify the binary exists before attempting to execute
+    if (!fs::exists(binary_path)) {
+        std::string msg = "Binary not found at: " + binary_path;
+        MESSAGE(msg);
+        return {-1, "", msg};
+    }
+
+    std::string cmd = binary_path + " " + args + " 2>&1";
+
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) {
+        return {-1, "", "Failed to execute command"};
+    }
+
+    std::stringstream ss;
+    char buffer[256];
+    while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+        ss << buffer;
+    }
+
+    int raw_status = pclose(pipe);
+    int exit_code = WIFEXITED(raw_status) ? WEXITSTATUS(raw_status) : -1;
+    return {exit_code, ss.str(), ""};
+}
+
+// Helper to create sample trace files
+void create_sample_trace(const std::string& path, int num_events = 10) {
+    std::ofstream file(path);
+    file << "[\n";
+    for (int i = 0; i < num_events; i++) {
+        file << R"({"id":)" << i
+             << R"(,"name":"read","cat":"POSIX","pid":12345,"tid":12345,)";
+        file << R"("ts":)" << (1000000 + i * 1000) << R"(,"dur":)"
+             << (100 + i * 10);
+        file << R"(,"ph":"X","args":{"fhash":"hash)" << i << R"(","size":)"
+             << (1024 * (i + 1));
+        file << R"(,"level":1}})";
+        if (i < num_events - 1) file << ",";
+        file << "\n";
+    }
+    file << "]";
+    file.close();
+}
+
+void create_multi_category_trace(const std::string& path) {
+    std::ofstream file(path);
+    file << "[\n";
+    file
+        << R"({"id":1,"name":"read","cat":"POSIX","pid":12345,"tid":12345,"ts":1000000,"dur":1500,"ph":"X","args":{"size":1024}})"
+        << ",\n";
+    file
+        << R"({"id":2,"name":"fopen","cat":"STDIO","pid":12345,"tid":12345,"ts":1002000,"dur":500,"ph":"X","args":{}})"
+        << ",\n";
+    file
+        << R"({"id":3,"name":"write","cat":"POSIX","pid":12345,"tid":12345,"ts":1003000,"dur":2000,"ph":"X","args":{"size":2048}})"
+        << ",\n";
+    file
+        << R"({"id":4,"name":"fread","cat":"STDIO","pid":12345,"tid":12345,"ts":1006000,"dur":800,"ph":"X","args":{"size":512}})"
+        << ",\n";
+    file
+        << R"({"id":5,"name":"open","cat":"POSIX","pid":12345,"tid":12345,"ts":1007500,"dur":300,"ph":"X","args":{}})"
+        << "\n";
+    file << "]";
+    file.close();
+}
+
+TEST_CASE("CI Replay Binary - Help and Version") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    SUBCASE("Test --help flag") {
+        auto result = execute_replay_binary("--help");
+        CHECK(result.exit_code == 0);
+        CHECK(result.stdout_output.find("DFTracer replay utility") !=
+              std::string::npos);
+        CHECK(result.stdout_output.find("--dftracer-mode") !=
+              std::string::npos);
+        CHECK(result.stdout_output.find("--dry-run") != std::string::npos);
+    }
+
+    SUBCASE("Test --version flag") {
+        auto result = execute_replay_binary("--version");
+        CHECK(result.exit_code == 0);
+        // Version output should be present
+        CHECK(!result.stdout_output.empty());
+    }
+}
+
+TEST_CASE("CI Replay Binary - Basic Replay Modes") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    fs::path temp_dir = fs::temp_directory_path() / "ci_replay_test";
+    fs::create_directories(temp_dir);
+    std::string trace_file = (temp_dir / "test_trace.pfw").string();
+
+    SUBCASE("Dry run mode") {
+        create_sample_trace(trace_file, 5);
+
+        auto result = execute_replay_binary("--dry-run " + trace_file);
+        CHECK(result.exit_code == 0);
+        CHECK(result.stdout_output.find("Replay Summary") != std::string::npos);
+        CHECK(result.stdout_output.find("Executed:") != std::string::npos);
+    }
+
+    SUBCASE("DFTracer mode with no-sleep") {
+        create_sample_trace(trace_file, 5);
+
+        auto result =
+            execute_replay_binary("--dftracer-mode --no-sleep " + trace_file);
+        CHECK(result.exit_code == 0);
+        CHECK(result.stdout_output.find("Replay Summary") != std::string::npos);
+    }
+
+    SUBCASE("DFTracer mode with timing disabled") {
+        create_sample_trace(trace_file, 5);
+
+        auto result =
+            execute_replay_binary("--dftracer-mode --no-timing " + trace_file);
+        CHECK(result.exit_code == 0);
+        CHECK(result.stdout_output.find("Executed:") != std::string::npos);
+    }
+
+    // Cleanup
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST_CASE("CI Replay Binary - Filtering Options") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    fs::path temp_dir = fs::temp_directory_path() / "ci_replay_filter_test";
+    fs::create_directories(temp_dir);
+    std::string trace_file = (temp_dir / "multi_category.pfw").string();
+
+    SUBCASE("Filter by category") {
+        create_multi_category_trace(trace_file);
+
+        auto result = execute_replay_binary(
+            "--dry-run --filter-category POSIX " + trace_file);
+        CHECK(result.exit_code == 0);
+        CHECK(result.stdout_output.find("Executed:") != std::string::npos);
+        CHECK(result.stdout_output.find("Filtered:") != std::string::npos);
+    }
+
+    SUBCASE("Filter by multiple categories") {
+        create_multi_category_trace(trace_file);
+
+        auto result = execute_replay_binary(
+            "--dry-run --filter-category POSIX,STDIO " + trace_file);
+        // Exit code may vary but should run
+    }
+
+    SUBCASE("Filter by function name") {
+        create_multi_category_trace(trace_file);
+
+        auto result = execute_replay_binary(
+            "--dry-run --filter-function read,write " + trace_file);
+        CHECK(result.stdout_output.find("Replay Summary") != std::string::npos);
+    }
+
+    SUBCASE("Max events limit") {
+        create_sample_trace(trace_file, 20);
+
+        auto result =
+            execute_replay_binary("--dry-run --max-events 10 " + trace_file);
+        CHECK(result.exit_code == 0);
+        // Verify it respects the limit
+        CHECK(result.stdout_output.find("Executed:") != std::string::npos);
+    }
+
+    // Cleanup
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST_CASE("CI Replay Binary - Sampling") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    fs::path temp_dir = fs::temp_directory_path() / "ci_replay_sampling_test";
+    fs::create_directories(temp_dir);
+    std::string trace_file = (temp_dir / "large_trace.pfw").string();
+
+    SUBCASE("50% deterministic sampling") {
+        create_sample_trace(trace_file, 100);
+
+        auto result = execute_replay_binary(
+            "--dry-run --sample-rate 0.5 --sample-seed 42 " + trace_file);
+        CHECK(result.exit_code == 0);
+        CHECK(result.stdout_output.find("Replay Summary") != std::string::npos);
+    }
+
+    SUBCASE("25% sampling") {
+        create_sample_trace(trace_file, 100);
+
+        auto result = execute_replay_binary(
+            "--dry-run --sample-rate 0.25 --sample-seed 42 " + trace_file);
+        CHECK(result.exit_code == 0);
+    }
+
+    SUBCASE("Invalid sampling rate (too high)") {
+        create_sample_trace(trace_file, 10);
+
+        auto result =
+            execute_replay_binary("--dry-run --sample-rate 1.5 " + trace_file);
+        // Should handle gracefully or fail with error
+        // The exact behavior depends on argparse validation
+    }
+
+    // Cleanup
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST_CASE("CI Replay Binary - Performance and Timing") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    fs::path temp_dir = fs::temp_directory_path() / "ci_replay_perf_test";
+    fs::create_directories(temp_dir);
+    std::string trace_file = (temp_dir / "perf_trace.pfw").string();
+
+    SUBCASE("Timing scale factor") {
+        create_sample_trace(trace_file, 10);
+
+        // Test with timing-scale flag
+        auto result =
+            execute_replay_binary("--dftracer-mode --no-sleep " + trace_file);
+        CHECK(result.exit_code == 0);
+    }
+
+    SUBCASE("Benchmark mode (no sleep, max speed)") {
+        create_sample_trace(trace_file, 50);
+
+        auto start = std::chrono::steady_clock::now();
+        auto result = execute_replay_binary(
+            "--dftracer-mode --no-sleep --no-timing " + trace_file);
+        auto end = std::chrono::steady_clock::now();
+
+        CHECK(result.exit_code == 0);
+
+        auto duration =
+            std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+        // With no-sleep and no-timing, should be very fast (< 5 seconds for 50
+        // events)
+        CHECK(duration.count() < 5000);
+    }
+
+    // Cleanup
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST_CASE("CI Replay Binary - Statistics and Verbose Output") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    fs::path temp_dir = fs::temp_directory_path() / "ci_replay_stats_test";
+    fs::create_directories(temp_dir);
+    std::string trace_file = (temp_dir / "stats_trace.pfw").string();
+
+    SUBCASE("Verbose mode") {
+        create_sample_trace(trace_file, 5);
+
+        auto result =
+            execute_replay_binary("--dry-run --verbose " + trace_file);
+        CHECK(result.exit_code == 0);
+        // Verbose output should contain detailed information
+        CHECK(result.stdout_output.find("Total events:") != std::string::npos);
+    }
+
+    SUBCASE("Statistics output") {
+        create_multi_category_trace(trace_file);
+
+        auto result = execute_replay_binary("--dry-run " + trace_file);
+        // Exit code may be non-zero but stats should be printed
+        CHECK(result.stdout_output.find("Replay Summary") != std::string::npos);
+        CHECK(result.stdout_output.find("Executed:") != std::string::npos);
+    }
+
+    SUBCASE("Per-function statistics") {
+        create_multi_category_trace(trace_file);
+
+        auto result =
+            execute_replay_binary("--dry-run --verbose " + trace_file);
+        // Should show breakdown by function - verify it runs
+        CHECK(!result.stdout_output.empty());
+    }
+
+    // Cleanup
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST_CASE("CI Replay Binary - Error Handling") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    SUBCASE("Non-existent trace file") {
+        auto result =
+            execute_replay_binary("--dry-run /nonexistent/path/trace.pfw");
+        // Should fail gracefully
+        CHECK(result.exit_code != 0);
+    }
+
+    SUBCASE("Invalid trace format") {
+        fs::path temp_dir = fs::temp_directory_path() / "ci_replay_error_test";
+        fs::create_directories(temp_dir);
+        std::string bad_trace = (temp_dir / "bad_trace.pfw").string();
+
+        // Create invalid JSON
+        std::ofstream file(bad_trace);
+        file << "this is not valid JSON";
+        file.close();
+
+        auto result = execute_replay_binary("--dry-run " + bad_trace);
+        // Should handle parse error gracefully
+        // May exit with error or skip invalid entries
+
+        std::error_code ec;
+        fs::remove_all(temp_dir, ec);
+    }
+
+    SUBCASE("Empty trace file") {
+        fs::path temp_dir = fs::temp_directory_path() / "ci_replay_empty_test";
+        fs::create_directories(temp_dir);
+        std::string empty_trace = (temp_dir / "empty_trace.pfw").string();
+
+        std::ofstream file(empty_trace);
+        file << "[]";
+        file.close();
+
+        auto result = execute_replay_binary("--dry-run " + empty_trace);
+        // Empty trace may exit with code 1, but should handle gracefully
+        CHECK(result.stdout_output.find("Replay Summary") != std::string::npos);
+
+        std::error_code ec;
+        fs::remove_all(temp_dir, ec);
+    }
+}
+
+TEST_CASE("CI Replay Binary - Multiple Files and Directories") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    fs::path temp_dir = fs::temp_directory_path() / "ci_replay_multi_test";
+    fs::create_directories(temp_dir);
+
+    SUBCASE("Multiple trace files") {
+        std::string trace1 = (temp_dir / "trace1.pfw").string();
+        std::string trace2 = (temp_dir / "trace2.pfw").string();
+
+        create_sample_trace(trace1, 5);
+        create_sample_trace(trace2, 5);
+
+        auto result =
+            execute_replay_binary("--dry-run " + trace1 + " " + trace2);
+        CHECK(result.exit_code == 0);
+        // Should process both files
+        CHECK(result.stdout_output.find("Replay Summary") != std::string::npos);
+    }
+
+    SUBCASE("Directory with trace files") {
+        fs::path trace_dir = temp_dir / "traces";
+        fs::create_directories(trace_dir);
+
+        create_sample_trace((trace_dir / "trace1.pfw").string(), 3);
+        create_sample_trace((trace_dir / "trace2.pfw").string(), 3);
+        create_sample_trace((trace_dir / "trace3.pfw").string(), 3);
+
+        auto result = execute_replay_binary("--dry-run " + trace_dir.string());
+        CHECK(result.exit_code == 0);
+        // Should process all files in directory
+    }
+
+    // Cleanup
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}
+
+TEST_CASE("CI Replay Binary - Call Tree Integration") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    // Test with actual trace files if available
+    std::string trace_dir = "trace_short/cosmoflow_h100/nodes-1";
+
+    SUBCASE("Call tree mode with real traces") {
+        if (!fs::is_directory(trace_dir)) {
+            MESSAGE("Skipping call tree test - directory not found: ",
+                    trace_dir);
+            return;
+        }
+
+        auto result = execute_replay_binary(
+            "--dry-run --use-call-tree --max-events 10 " + trace_dir);
+        CHECK(result.exit_code == 0);
+        // Should show node statistics
+    }
+
+    SUBCASE("Hierarchical replay with call tree") {
+        if (!fs::is_directory(trace_dir)) {
+            MESSAGE("Skipping hierarchical replay test - directory not found: ",
+                    trace_dir);
+            return;
+        }
+
+        auto result = execute_replay_binary(
+            "--dftracer-mode --use-call-tree --no-sleep --max-events 10 " +
+            trace_dir);
+        CHECK(result.exit_code == 0);
+    }
+}
+
+TEST_CASE("CI Replay Binary - Integration with Real Traces") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    SUBCASE("BERT trace replay") {
+        std::string trace_file = "trace_short/bert_v100-1.pfw";
+
+        if (!fs::exists(trace_file)) {
+            MESSAGE("Skipping BERT trace test - file not found: ", trace_file);
+            return;
+        }
+
+        auto result = execute_replay_binary(
+            "--dftracer-mode --no-sleep --max-events 100 " + trace_file);
+        CHECK(result.exit_code == 0);
+        CHECK(result.stdout_output.find("Total events:") != std::string::npos);
+    }
+
+    SUBCASE("CosmoFlow A100 trace replay") {
+        std::string trace_dir = "trace_short/cosmoflow_a100";
+
+        if (!fs::is_directory(trace_dir)) {
+            MESSAGE("Skipping CosmoFlow A100 test - directory not found: ",
+                    trace_dir);
+            return;
+        }
+
+        auto result =
+            execute_replay_binary("--dry-run --max-events 50 " + trace_dir);
+        CHECK(result.exit_code == 0);
+    }
+
+    SUBCASE("CosmoFlow H100 trace replay") {
+        std::string trace_dir = "trace_short/cosmoflow_h100";
+
+        if (!fs::is_directory(trace_dir)) {
+            MESSAGE("Skipping CosmoFlow H100 test - directory not found: ",
+                    trace_dir);
+            return;
+        }
+
+        auto result = execute_replay_binary(
+            "--dftracer-mode --no-sleep --sample-rate 0.1 "
+            "--sample-seed 42 " +
+            trace_dir);
+        CHECK(result.exit_code == 0);
+    }
+}
+
+TEST_CASE("CI Replay Binary - Stress Testing") {
+    DFTRACER_UTILS_LOGGER_INIT();
+
+    fs::path temp_dir = fs::temp_directory_path() / "ci_replay_stress_test";
+    fs::create_directories(temp_dir);
+
+    SUBCASE("Large trace file (1000 events)") {
+        std::string large_trace = (temp_dir / "large_trace.pfw").string();
+        create_sample_trace(large_trace, 1000);
+
+        auto start = std::chrono::steady_clock::now();
+        auto result = execute_replay_binary("--dry-run " + large_trace);
+        auto end = std::chrono::steady_clock::now();
+
+        CHECK(result.exit_code == 0);
+
+        auto duration =
+            std::chrono::duration_cast<std::chrono::seconds>(end - start);
+        // Should complete reasonably fast (< 10 seconds for 1000 events in dry
+        // run)
+        CHECK(duration.count() < 10);
+    }
+
+    SUBCASE("High sampling rate with large file") {
+        std::string large_trace = (temp_dir / "large_trace2.pfw").string();
+        create_sample_trace(large_trace, 500);
+
+        auto result = execute_replay_binary(
+            "--dftracer-mode --no-sleep --sample-rate 0.9 --sample-seed 42 " +
+            large_trace);
+        CHECK(result.exit_code == 0);
+    }
+
+    // Cleanup
+    std::error_code ec;
+    fs::remove_all(temp_dir, ec);
+}

--- a/tests/utilities/CMakeLists.txt
+++ b/tests/utilities/CMakeLists.txt
@@ -130,5 +130,11 @@ foreach(test_file ${UTILITIES_TEST_SOURCES})
     target_link_libraries(${target_name} PRIVATE --coverage)
   endif()
 
+  set(test_working_directory
+      "${CMAKE_CURRENT_BINARY_DIR}/workdirs/${target_name}")
+  file(MAKE_DIRECTORY "${test_working_directory}")
+
   add_test(NAME utilities/${bin_exec} COMMAND ${target_name})
+  set_tests_properties(utilities/${bin_exec} PROPERTIES
+                       WORKING_DIRECTORY "${test_working_directory}")
 endforeach()


### PR DESCRIPTION
This PR introduces the dftracer replay functionality with interfaces to the new call-tree API. It adds the following components for the functionality: 
- Dftracer replay feature
- Unit tests, standalone binary test
- Documentation
- Test binary for call-tree functionality (missing previously)

Fixes #9.